### PR TITLE
docs: clarify Banco de Chile is balance-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Scrapers open source para bancos chilenos. Obtén tus movimientos bancarios y sa
 | Banco Falabella | `falabella` | ✅ Funcional |
 | Banco BICE | `bice` | ✅ Funcional |
 | Banco Santander | `santander` | ✅ Funcional |
-| Banco de Chile | `bchile` | ✅ Funcional |
+| Banco de Chile | `bchile` | 🟡 Solo saldo |
 | BCI | `bci` | 🔜 Próximamente |
 | Banco Estado | `estado` | 🔜 Próximamente |
 


### PR DESCRIPTION
## Summary
- Updates README to show Banco de Chile as `🟡 Solo saldo` instead of `✅ Funcional`
- The bchile scraper from PR #5 only supports balance queries, not movements
- All other scrapers (Falabella, BICE, Santander) return full transaction history

Movements support is expected as a follow-up from @bcortezf.