### PR TITLE
security: harden screenshot handling and 2FA timeout bounds

### DIFF
--- a/src/banks/bchile.ts
+++ b/src/banks/bchile.ts
@@ -353,7 +353,7 @@ async function login(
 
   // Check for 2FA
   if (await has2FAChallenge(page)) {
-    const timeoutSec = Math.max(30, parseInt(process.env.BCHILE_2FA_TIMEOUT_SEC || "180", 10));
+    const timeoutSec = Math.min(600, Math.max(30, parseInt(process.env.BCHILE_2FA_TIMEOUT_SEC || "180", 10)));
     const timeoutMs = timeoutSec * 1000;
     debugLog.push(`  2FA detectado. Esperando aprobación manual (${timeoutSec}s máx)...`);
     const deadline = Date.now() + timeoutMs;

--- a/src/banks/bci.ts
+++ b/src/banks/bci.ts
@@ -12,7 +12,7 @@ const IFRAME_PATTERNS = {
 } as const;
 
 const TWO_FA_KEYWORDS = ["bci pass", "segundo factor", "aprobación en tu app", "autorizar en tu app", "confirmar en tu app"];
-const TWO_FA_TIMEOUT_SEC = Math.max(30, parseInt(process.env.BCI_2FA_TIMEOUT_SEC || "180", 10) || 180);
+const TWO_FA_TIMEOUT_SEC = Math.min(600, Math.max(30, parseInt(process.env.BCI_2FA_TIMEOUT_SEC || "180", 10) || 180));
 
 const TC_COMBINATIONS = [
   { tab: "Nacional $", billingType: "No facturados", prefix: "[TC No Facturado]" },

--- a/src/banks/edwards.ts
+++ b/src/banks/edwards.ts
@@ -814,12 +814,13 @@ async function scrape(options: ScraperOptions): Promise<ScrapeResult> {
     await doSave(page, "02-after-login");
 
     // When --screenshots: save HTML for DOM inspection (debug/ is in .gitignore)
+    // ⚠️  Este HTML contiene datos bancarios autenticados — no compartir ni commitear
     if (doScreenshots) {
       const html = await page.content();
       const debugDir = path.resolve("debug");
       if (!fs.existsSync(debugDir)) fs.mkdirSync(debugDir, { recursive: true });
       fs.writeFileSync(path.join(debugDir, "02-after-login.html"), html, "utf8");
-      debugLog.push("  HTML saved: debug/02-after-login.html");
+      debugLog.push("  HTML saved: debug/02-after-login.html (⚠️ contiene datos bancarios)");
     }
 
     // Banco de Chile/Edwards: no 2FA in login flow
@@ -878,7 +879,7 @@ async function scrape(options: ScraperOptions): Promise<ScrapeResult> {
       const debugDir = path.resolve("debug");
       if (!fs.existsSync(debugDir)) fs.mkdirSync(debugDir, { recursive: true });
       fs.writeFileSync(path.join(debugDir, "03-movements-page.html"), html, "utf8");
-      debugLog.push("  HTML saved: debug/03-movements-page.html");
+      debugLog.push("  HTML saved: debug/03-movements-page.html (⚠️ contiene movimientos bancarios)");
     }
 
     // Step 7: Expand date range if available
@@ -926,7 +927,7 @@ async function scrape(options: ScraperOptions): Promise<ScrapeResult> {
         const debugDir = path.resolve("debug");
         if (!fs.existsSync(debugDir)) fs.mkdirSync(debugDir, { recursive: true });
         fs.writeFileSync(path.join(debugDir, "03-tc-movements.html"), html, "utf8");
-        debugLog.push("  HTML saved: debug/03-tc-movements.html");
+        debugLog.push("  HTML saved: debug/03-tc-movements.html (⚠️ contiene movimientos tarjeta)");
       }
       const porFacturar = await clickTcTab(page, "por-facturar");
       if (porFacturar) {

--- a/src/banks/itau.ts
+++ b/src/banks/itau.ts
@@ -86,7 +86,7 @@ async function has2FAChallenge(page: Page): Promise<boolean> {
 }
 
 async function waitFor2FA(page: Page, debugLog: string[]): Promise<boolean> {
-  const timeoutSec = Math.max(30, parseInt(process.env.ITAU_2FA_TIMEOUT_SEC || "180", 10) || 180);
+  const timeoutSec = Math.min(600, Math.max(30, parseInt(process.env.ITAU_2FA_TIMEOUT_SEC || "180", 10) || 180));
   const deadline = Date.now() + timeoutSec * 1000;
   let pollCount = 0;
 

--- a/src/banks/santander.ts
+++ b/src/banks/santander.ts
@@ -1006,7 +1006,7 @@ async function scrape(options: ScraperOptions): Promise<ScrapeResult> {
 
     let pageContent = await getCombinedPageText(page);
     if (has2FAChallenge(pageContent)) {
-      const waitSeconds = Math.max(30, parseInt(process.env.SANTANDER_2FA_TIMEOUT_SEC || "180", 10) || 180);
+      const waitSeconds = Math.min(600, Math.max(30, parseInt(process.env.SANTANDER_2FA_TIMEOUT_SEC || "180", 10) || 180));
       debugLog.push(`  2FA detectado. Esperando aprobación manual (${waitSeconds}s máx)...`);
       const approved = await waitForManual2FA(page, debugLog, waitSeconds);
       await doSave(page, "03b-after-2fa-wait");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,6 +96,13 @@ Ejemplos:
     process.exit(1);
   }
 
+  if (flags.has("--screenshots")) {
+    console.warn(
+      "⚠️  --screenshots guarda imágenes y HTML con datos bancarios en ./screenshots/ y ./debug/\n" +
+      "   No compartas estos archivos ni los subas a git."
+    );
+  }
+
   const result = await bank.scrape({
     rut,
     password,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,13 +50,15 @@ export async function saveScreenshot(
   debugLog: string[]
 ): Promise<void> {
   if (!enabled) return;
+  // Sanitize name to prevent path traversal
+  const safeName = name.replace(/[/\\:*?"<>|]/g, "_");
   const dir = path.resolve("screenshots");
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   await page.screenshot({
-    path: path.join(dir, `${name}.png`),
+    path: path.join(dir, `${safeName}.png`),
     fullPage: true,
   });
-  debugLog.push(`  Screenshot saved: screenshots/${name}.png`);
+  debugLog.push(`  Screenshot saved: screenshots/${safeName}.png`);
 }
 
 /** Cierra popups y modales genéricos */


### PR DESCRIPTION
Small non-breaking security hardening across all scrapers:

- **`utils.ts`**: sanitize `name` param in `saveScreenshot()` to strip path separators — prevents theoretical path traversal if any future caller passes external data
- **`cli.ts`**: print warning when `--screenshots` flag is active, reminding user that `./screenshots/` and `./debug/` contain sensitive bank data
- **`edwards.ts`**: annotate the three HTML debug dump log entries with ⚠️ to make clear the files contain authenticated bank data
- **`bci/bchile/itau/santander`**: cap 2FA timeout env vars at 600s with `Math.min(600, ...)` — was unbounded, meaning a very large value could hold a browser session open indefinitely

No changes to scraping logic, selectors, or output format.