### PR TITLE
fix(scotiabank): cast Element a HTMLElement para acceder a innerText

### DIFF
--- a/src/banks/scotiabank.ts
+++ b/src/banks/scotiabank.ts
@@ -528,7 +528,7 @@ async function scrapeScotiabank(session: BrowserSession, options: ScraperOptions
           try {
             clickedConsultar = await frame.evaluate(() => {
               for (const el of document.querySelectorAll("a, button, span, div")) {
-                const text = el.innerText?.trim().toLowerCase() || "";
+                const text = (el as HTMLElement).innerText?.trim().toLowerCase() || "";
                 if (text.includes("consultar cartola") && text.length < 40) {
                   (el as HTMLElement).click(); return true;
                 }


### PR DESCRIPTION
`npm install` falla para todos los usuarios nuevos debido a un error
de tipos en el paso `prepare`, que ejecuta el build automáticamente.

Error:
src/banks/scotiabank.ts(531,33): error TS2339: Property 'innerText'
does not exist on type 'Element'.

`document.querySelectorAll()` retorna `NodeListOf<Element>`, pero
`innerText` solo existe en `HTMLElement`. TypeScript lo detecta al
generar las declaraciones `.d.ts` y falla el build completo.

querySelectorAll retorna NodeListOf<Element> pero innerText solo existe en HTMLElement. El cast corrige el error de compilación DTS. 