### PR TITLE
feat(santander): extracción de metadata de tarjetas de crédito (cupo, facturación, último estado)

### DIFF
--- a/src/banks/santander.test.ts
+++ b/src/banks/santander.test.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { MOVEMENT_SOURCE } from "../types.js";
 import {
   isSaldoInicial,
   normalizeSantanderCheckingApiMovements,
   normalizeSantanderUnbilledApiMovements,
   normalizeSantanderBilledApiMovements,
+  parseUsdAmount,
+  creditCardDedupKey,
+  buildCreditCardFromRaw,
 } from "./santander.js";
 
 // ─── isSaldoInicial ──────────────────────────────────────────────
@@ -339,5 +342,90 @@ describe("normalizeSantanderBilledApiMovements", () => {
   it("skips captures with missing nested path", () => {
     expect(normalizeSantanderBilledApiMovements([{}])).toEqual([]);
     expect(normalizeSantanderBilledApiMovements([{ DATA: {} }])).toEqual([]);
+  });
+});
+
+// ─── parseUsdAmount ──────────────────────────────────────────────
+
+describe("parseUsdAmount", () => {
+  it("parses Chilean-formatted USD amounts (. thousands, , decimals)", () => {
+    expect(parseUsdAmount("USD 1.234,56")).toBeCloseTo(1234.56);
+    expect(parseUsdAmount("$ 2.000,00")).toBe(2000);
+    expect(parseUsdAmount("500,50")).toBeCloseTo(500.5);
+  });
+
+  it("returns 0 for empty/null without warning (no USD section is normal)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(parseUsdAmount(null)).toBe(0);
+    expect(parseUsdAmount(undefined)).toBe(0);
+    expect(parseUsdAmount("")).toBe(0);
+    expect(parseUsdAmount("   ")).toBe(0);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("warns and returns 0 when a non-empty value cannot be parsed (format change)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(parseUsdAmount("N/A")).toBe(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("formato inesperado");
+    warn.mockRestore();
+  });
+});
+
+// ─── creditCardDedupKey ──────────────────────────────────────────
+
+describe("creditCardDedupKey", () => {
+  it("keeps twin cards (same product/balance, different last4) apart", () => {
+    const a = { label: "Mastercard Black ****1234", national: { used: 0, available: 0, total: 1_000_000 } };
+    const b = { label: "Mastercard Black ****5678", national: { used: 0, available: 0, total: 1_000_000 } };
+    expect(creditCardDedupKey(a)).not.toBe(creditCardDedupKey(b));
+  });
+
+  it("collapses swiper clones (identical last4)", () => {
+    const a = { label: "Visa Gold ****4321", national: { used: 0, available: 0, total: 500_000 } };
+    const clone = { label: "Visa Gold ****4321", national: { used: 1, available: 2, total: 500_000 } };
+    expect(creditCardDedupKey(a)).toBe(creditCardDedupKey(clone));
+  });
+
+  it("falls back to label+totals when no last4 is present", () => {
+    const a = { label: "Tarjeta Santander", national: { used: 0, available: 0, total: 100 } };
+    const b = { label: "Tarjeta Santander", national: { used: 0, available: 0, total: 200 } };
+    expect(creditCardDedupKey(a)).not.toBe(creditCardDedupKey(b));
+    expect(creditCardDedupKey(a)).toBe(creditCardDedupKey({ ...a }));
+  });
+});
+
+// ─── buildCreditCardFromRaw (selector parsing smoke test) ────────
+
+describe("buildCreditCardFromRaw", () => {
+  it("parses at least one card with national + international cupo", () => {
+    const card = buildCreditCardFromRaw({
+      cardName: "Mastercard Black",
+      last4: "5824",
+      sections: [
+        { header: "Cupo Nacional", available: "700.000", used: "300.000", total: "1.000.000", currency: "CLP" },
+        { header: "Cupo en Dólares", available: "1.500,00", used: "500,00", total: "2.000,00", currency: "USD" },
+      ],
+      billingPeriod: "Febrero 2026",
+      nextBillingDate: "05-03-2026",
+    });
+    expect(card).not.toBeNull();
+    expect(card!.label).toBe("Mastercard Black ****5824");
+    expect(card!.national).toEqual({ used: 300_000, available: 700_000, total: 1_000_000 });
+    expect(card!.international).toEqual({ used: 500, available: 1500, total: 2000, currency: "USD" });
+    expect(card!.billingPeriod).toBe("Febrero 2026");
+    expect(card!.nextBillingDate).toBe("05-03-2026");
+  });
+
+  it("returns null when no cupo section yields data (selectors broke)", () => {
+    const card = buildCreditCardFromRaw({
+      cardName: "Visa",
+      last4: "0000",
+      sections: [{ header: "", available: null, used: null, total: null, currency: "CLP" }],
+      billingPeriod: null,
+      nextBillingDate: null,
+    });
+    expect(card).toBeNull();
   });
 });

--- a/src/banks/santander.ts
+++ b/src/banks/santander.ts
@@ -1,5 +1,5 @@
 import type { Frame, Page } from "puppeteer-core";
-import type { BankMovement, BankScraper, ScrapeResult, ScraperOptions } from "../types.js";
+import type { BankMovement, BankScraper, CreditCardBalance, ScrapeResult, ScraperOptions } from "../types.js";
 import { MOVEMENT_SOURCE } from "../types.js";
 import { deduplicateMovements, closePopups, delay, normalizeDate, parseChileanAmount } from "../utils.js";
 import { createInterceptor } from "../intercept.js";
@@ -175,6 +175,7 @@ const TWO_FACTOR_CONFIG = {
 // ─── Santander-specific helpers ──────────────────────────────────────
 
 type MovementAccount = { index: number; label: string };
+type CreditCardSlide = { index: number; label: string };
 
 async function getLoginFrame(page: Page): Promise<Frame | null> {
   const handle = await page.$("iframe#login-frame");
@@ -312,6 +313,323 @@ async function navigateToCreditCardSection(page: Page, debugLog: string[]): Prom
   }
 
   return page.url().toLowerCase().includes("saldos_tc");
+}
+
+function formatCardLabel(cardName?: string, last4?: string): string {
+  const name = (cardName || "Tarjeta Santander").replace(/\s+/g, " ").trim();
+  if (!last4) return name;
+  if (name.includes(last4) || name.includes(`****${last4}`)) return name;
+  return `${name} ****${last4}`;
+}
+
+function parseUsdAmount(text?: string | null): number {
+  const clean = (text || "").replace(/[^0-9.,-]/g, "");
+  if (!clean) return 0;
+  const normalized = clean.replace(/\./g, "").replace(",", ".");
+  const amount = Number.parseFloat(normalized);
+  return Number.isNaN(amount) ? 0 : amount;
+}
+
+async function getActiveCreditCardSlideIndex(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const slides = Array.from(document.querySelectorAll(".container-carusel .swiper-slide"));
+    return slides.findIndex((slide) => (slide as HTMLElement).className.includes("swiper-slide-active"));
+  });
+}
+
+async function listCreditCardSlides(page: Page): Promise<CreditCardSlide[]> {
+  const rawSlides = await page.evaluate(() => {
+    const slides = Array.from(document.querySelectorAll(".container-carusel .swiper-slide"));
+    return slides
+      .map((slide, index) => {
+        const text = (slide as HTMLElement).innerText?.replace(/\s+/g, " ").trim() || "";
+        if (!text) return null;
+
+        const cardName =
+          text.match(/^(.*?)\s+Cupo Disponible/i)?.[1]?.trim() ||
+          text.match(/^(.*?)\s+\$\s*[\d.,]+/i)?.[1]?.trim() ||
+          "";
+        const last4 = text.match(/\*\s*(\d{4})/)?.[1] || text.match(/(\d{4})(?!.*\d)/)?.[1] || "";
+        return { index, cardName, last4 };
+      })
+      .filter((slide): slide is { index: number; cardName: string; last4: string } => Boolean(slide));
+  });
+
+  return rawSlides.map((slide) => ({
+    index: slide.index,
+    label: formatCardLabel(slide.cardName, slide.last4),
+  }));
+}
+
+async function selectCreditCardSlide(page: Page, index: number): Promise<boolean> {
+  const clicked = await page.evaluate((targetIndex: number) => {
+    const byAria = document.querySelector(
+      `.container-carusel [aria-label='Go to slide ${targetIndex + 1}']`,
+    ) as HTMLElement | null;
+    if (byAria) {
+      byAria.click();
+      return true;
+    }
+
+    const dots = Array.from(document.querySelectorAll(".container-carusel .swiper-pagination-bullet"));
+    if (dots[targetIndex]) {
+      (dots[targetIndex] as HTMLElement).click();
+      return true;
+    }
+
+    const slides = Array.from(document.querySelectorAll(".container-carusel .swiper-slide"));
+    if (slides[targetIndex]) {
+      const slide = slides[targetIndex] as HTMLElement;
+      const clickable =
+        (slide.querySelector(".container-image, .container-tcr") as HTMLElement | null) ||
+        slide;
+      clickable.click();
+      return true;
+    }
+
+    return false;
+  }, index);
+
+  if (!clicked) return false;
+  await delay(1200);
+
+  if ((await getActiveCreditCardSlideIndex(page)) === index) return true;
+  await delay(1800);
+  return (await getActiveCreditCardSlideIndex(page)) === index;
+}
+
+async function extractActiveCreditCardMetadata(page: Page): Promise<CreditCardBalance | null> {
+  const raw = await page.evaluate(() => {
+    const normalizeText = (value?: string | null) => value?.replace(/\s+/g, " ").trim() || "";
+    const activeSlide = document.querySelector(
+      ".container-carusel .swiper-slide.swiper-slide-active",
+    ) as HTMLElement | null;
+    const slideText = normalizeText(activeSlide?.innerText);
+
+    const cardName =
+      slideText.match(/^(.*?)\s+Cupo Disponible/i)?.[1]?.trim() ||
+      slideText.match(/^(.*?)\s+\$\s*[\d.,]+/i)?.[1]?.trim() ||
+      "";
+    const last4 =
+      slideText.match(/\*\s*(\d{4})/)?.[1] ||
+      slideText.match(/(\d{4})(?!.*\d)/)?.[1] ||
+      "";
+
+    const sections = Array.from(
+      document.querySelectorAll(".card-detail .balance__container"),
+    ).map((section) => {
+      const header = normalizeText(
+        (section.querySelector(".header .big") as HTMLElement | null)?.innerText ||
+          (section.querySelector(".header") as HTMLElement | null)?.innerText,
+      );
+      const text = normalizeText((section as HTMLElement).innerText);
+      const available = text.match(/Disponible\s+(?:USD|\$)?\s*([\d.,]+)/i)?.[1] || null;
+      const used = text.match(/Utilizado\s+(?:USD|\$)?\s*([\d.,]+)/i)?.[1] || null;
+      const total = text.match(/Autorizado\s+(?:USD|\$)?\s*([\d.,]+)/i)?.[1] || null;
+      const currency = header.toLowerCase().includes("dólar") || header.toLowerCase().includes("dolar")
+        ? "USD"
+        : "CLP";
+
+      return { header, available, used, total, currency };
+    });
+
+    const bodyText = normalizeText(document.body?.innerText);
+    const billingPeriod =
+      bodyText.match(/Periodo de facturaci[oó]n\s+([^\n]+)/i)?.[1]?.trim() || null;
+    const nextBillingDate =
+      bodyText.match(
+        /Pr[oó]xima facturaci[oó]n\s+(\d{1,2}[\/.\-]\d{1,2}(?:[\/.\-]\d{2,4})?|\d{1,2}\s+[A-Za-záéíóúñ]+\s+\d{4})/i,
+      )?.[1] || null;
+
+    return { cardName, last4, sections, billingPeriod, nextBillingDate };
+  });
+
+  const label = formatCardLabel(raw.cardName, raw.last4);
+  const card: CreditCardBalance = { label };
+
+  for (const section of raw.sections) {
+    if (!section.available && !section.used && !section.total) continue;
+
+    if (section.currency === "USD") {
+      card.international = {
+        used: Math.abs(parseUsdAmount(section.used)),
+        available: parseUsdAmount(section.available),
+        total: parseUsdAmount(section.total),
+        currency: "USD",
+      };
+      continue;
+    }
+
+    card.national = {
+      used: Math.abs(parseChileanAmount(section.used || "0")),
+      available: parseChileanAmount(section.available || "0"),
+      total: parseChileanAmount(section.total || "0"),
+    };
+  }
+
+  if (!card.national && !card.international) return null;
+  if (raw.billingPeriod) card.billingPeriod = raw.billingPeriod;
+  if (raw.nextBillingDate) card.nextBillingDate = raw.nextBillingDate;
+  return card;
+}
+
+async function extractCreditCardMetadata(page: Page, debugLog: string[]): Promise<CreditCardBalance[]> {
+  const slides = await listCreditCardSlides(page);
+  const activeIndex = await getActiveCreditCardSlideIndex(page);
+  const seen = new Set<string>();
+  const creditCards: CreditCardBalance[] = [];
+
+  const captureCurrentSlide = async (slide: CreditCardSlide | null) => {
+    const metadata = await extractActiveCreditCardMetadata(page);
+    if (!metadata) return;
+
+    const key = `${metadata.label}|${metadata.national?.total ?? ""}|${metadata.international?.total ?? ""}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    creditCards.push(metadata);
+
+    const national =
+      metadata.national
+        ? `CLP total=$${metadata.national.total.toLocaleString("es-CL")}, used=$${metadata.national.used.toLocaleString("es-CL")}, available=$${metadata.national.available.toLocaleString("es-CL")}`
+        : "sin cupo CLP";
+    const international =
+      metadata.international
+        ? `USD total=${metadata.international.total}, used=${metadata.international.used}, available=${metadata.international.available}`
+        : "sin cupo USD";
+
+    debugLog.push(`  TC metadata${slide ? ` [${slide.label}]` : ""}: ${national}; ${international}`);
+  };
+
+  if (slides.length === 0) {
+    await captureCurrentSlide(null);
+    return creditCards;
+  }
+
+  for (const slide of slides) {
+    const switched = slide.index === activeIndex || (await selectCreditCardSlide(page, slide.index));
+    if (!switched) {
+      debugLog.push(`  Could not switch to credit card slide ${slide.index + 1}: ${slide.label}`);
+      continue;
+    }
+    await captureCurrentSlide(slide);
+  }
+
+  if (activeIndex >= 0) {
+    await selectCreditCardSlide(page, activeIndex);
+  }
+
+  return creditCards;
+}
+
+type LastStatementRaw = {
+  billingDate?: string;
+  billedAmount?: number;
+  dueDate?: string;
+  minimumPayment?: number;
+};
+
+const MONTH_NAMES = [
+  "Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio",
+  "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre",
+] as const;
+
+function normalizeDateDashes(value?: string | null): string | undefined {
+  if (!value) return undefined;
+  const match = value.trim().match(/^(\d{1,2})[\/\-.](\d{1,2})[\/\-.](\d{2,4})$/);
+  if (!match) return undefined;
+  const [, dd, mm, yy] = match;
+  const year = yy.length === 2 ? `20${yy}` : yy;
+  return `${dd.padStart(2, "0")}-${mm.padStart(2, "0")}-${year}`;
+}
+
+function billingPeriodFromDate(billingDate?: string): string | undefined {
+  if (!billingDate) return undefined;
+  const match = billingDate.match(/^\d{2}-(\d{2})-(\d{4})$/);
+  if (!match) return undefined;
+  const monthIdx = Number.parseInt(match[1], 10) - 1;
+  const year = match[2];
+  if (monthIdx < 0 || monthIdx > 11) return undefined;
+  return `${MONTH_NAMES[monthIdx]} ${year}`;
+}
+
+async function waitForStatementRender(page: Page, timeoutMs = 10_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const ready = await page.evaluate(() => {
+      const txt = document.body?.innerText?.replace(/\s+/g, " ") || "";
+      return /Monto\s*total\s*facturado|Pagar\s*hasta/i.test(txt);
+    });
+    if (ready) return true;
+    await delay(500);
+  }
+  return false;
+}
+
+async function extractLastStatement(page: Page): Promise<LastStatementRaw> {
+  return await page.evaluate(() => {
+    const normalize = (value?: string | null) => value?.replace(/\s+/g, " ").trim() || "";
+    const bodyText = normalize(document.body?.innerText);
+    const dateRe = /(\d{1,2}[\/\-.]\d{1,2}[\/\-.]\d{2,4})/;
+    const amountRe = /\$\s*([\d.,]+)/;
+
+    // Text-based matcher near a label. Keep the window tight (default 40)
+    // so we don't accidentally pair a label with the next section's value —
+    // e.g. "Fecha facturación" jumping ahead to "Pagar hasta 08/05/2026".
+    const nearLabel = (labelRe: string, valueRe: RegExp, windowChars = 40): string | null => {
+      const re = new RegExp(`${labelRe}[\\s\\S]{0,${windowChars}}?${valueRe.source}`, "i");
+      return bodyText.match(re)?.[1] || null;
+    };
+
+    // Billing date lives inside an Angular Material mat-select; its selected
+    // value is rendered in a `.mat-select-min-line` span that is NOT reflected
+    // in document.body.innerText. Find the first such span whose text looks
+    // like a date.
+    const billingDateFromDom = (() => {
+      for (const el of document.querySelectorAll<HTMLElement>(".mat-select-min-line")) {
+        const txt = (el.textContent || "").replace(/\s+/g, " ").trim();
+        if (/^\d{1,2}[\/\-.]\d{1,2}[\/\-.]\d{2,4}$/.test(txt)) return txt;
+      }
+      return null;
+    })();
+
+    const billingDate = billingDateFromDom;
+    const dueDate = nearLabel("Pagar\\s*hasta", dateRe);
+    const billedAmountRaw = nearLabel("Monto\\s*total\\s*facturado", amountRe, 80);
+    const minimumPaymentRaw = nearLabel("Pago\\s*M[ií]nimo(?:\\s*del\\s*mes)?", amountRe, 80);
+
+    const parseAmount = (raw: string | null): number | null => {
+      if (!raw) return null;
+      const clean = raw.replace(/[^0-9.,-]/g, "").replace(/\./g, "").replace(",", ".");
+      const n = Number.parseFloat(clean);
+      return Number.isNaN(n) ? null : Math.round(n);
+    };
+
+    return {
+      billingDate: billingDate || undefined,
+      dueDate: dueDate || undefined,
+      billedAmount: parseAmount(billedAmountRaw) ?? undefined,
+      minimumPayment: parseAmount(minimumPaymentRaw) ?? undefined,
+    };
+  });
+}
+
+function applyLastStatement(card: CreditCardBalance, raw: LastStatementRaw): boolean {
+  const billingDate = normalizeDateDashes(raw.billingDate);
+  const dueDate = normalizeDateDashes(raw.dueDate);
+  if (!billingDate || !dueDate || raw.billedAmount === undefined) return false;
+
+  card.lastStatement = {
+    billingDate,
+    billedAmount: raw.billedAmount,
+    dueDate,
+    ...(raw.minimumPayment !== undefined ? { minimumPayment: raw.minimumPayment } : {}),
+  };
+  if (!card.nextDueDate) card.nextDueDate = dueDate;
+  if (!card.billingPeriod) {
+    const derived = billingPeriodFromDate(billingDate);
+    if (derived) card.billingPeriod = derived;
+  }
+  return true;
 }
 
 // ─── Main scrape function ────────────────────────────────────────────
@@ -465,11 +783,30 @@ async function scrapeSantander(
   }
   movements = deduplicateMovements(movements);
 
+  let balance: number | undefined;
+  const withBalance = movements.find((m) => m.balance > 0);
+  if (withBalance) {
+    balance = withBalance.balance;
+    debugLog.push(`  Balance from account movements: $${balance.toLocaleString("es-CL")}`);
+  }
+  if (balance === undefined || balance === 0) {
+    balance = await extractBalance(page);
+    if (balance !== undefined) {
+      debugLog.push(`  Balance from account page: $${balance.toLocaleString("es-CL")}`);
+    }
+  }
+
   // 7b. Credit card movements
   debugLog.push("7b. Navigating to credit card movements...");
   progress("Extrayendo movimientos de tarjeta de crédito...");
+  let creditCards: CreditCardBalance[] | undefined;
   const tcReady = await navigateToCreditCardSection(page, debugLog);
   if (tcReady) {
+    const metadata = await extractCreditCardMetadata(page, debugLog);
+    if (metadata.length > 0) {
+      creditCards = metadata;
+    }
+
     if (await clickTcTab(page, "movimientos por facturar")) {
       const unbilledCaptures = await interceptor.waitFor("santander-credit-card-unbilled", 10_000);
       if (unbilledCaptures.length > 0) {
@@ -495,22 +832,41 @@ async function scrapeSantander(
         movements.push(...billed);
         debugLog.push(`  TC facturados: ${billed.length} movement(s)`);
       }
+
+      if (creditCards && creditCards.length > 0) {
+        // Re-select the "movimientos facturados" tab. The API interception
+        // above captures movements without requiring the UI to stay on the
+        // tab — but the billing summary (statement info) is only rendered
+        // inside that tab's view, and other actions (carousel nav, tab
+        // switching) can push the UI back to "Mi Tarjeta" before we extract.
+        await clickTcTab(page, "movimientos facturados");
+        const rendered = await waitForStatementRender(page);
+        if (!rendered) {
+          debugLog.push(`  Statement anchor text did not appear within 10s`);
+        }
+        const statementRaw = await extractLastStatement(page);
+        const card = creditCards[0];
+        if (applyLastStatement(card, statementRaw)) {
+          debugLog.push(
+            `  Last statement [${card.label}]: billed=$${card.lastStatement!.billedAmount.toLocaleString("es-CL")}, ` +
+            `billingDate=${card.lastStatement!.billingDate}, dueDate=${card.lastStatement!.dueDate}` +
+            (card.lastStatement!.minimumPayment !== undefined
+              ? `, min=$${card.lastStatement!.minimumPayment.toLocaleString("es-CL")}`
+              : ""),
+          );
+        } else {
+          debugLog.push(
+            `  Last statement [${card.label}]: partial (billingDate=${statementRaw.billingDate ?? "—"}, ` +
+            `dueDate=${statementRaw.dueDate ?? "—"}, billed=${statementRaw.billedAmount ?? "—"}, ` +
+            `min=${statementRaw.minimumPayment ?? "—"})`,
+          );
+        }
+      }
     }
   } else {
     debugLog.push("  Could not open credit card section.");
   }
   movements = deduplicateMovements(movements);
-
-  // 8. Balance
-  let balance: number | undefined;
-  const withBalance = movements.find((m) => m.balance > 0);
-  if (withBalance) {
-    balance = withBalance.balance;
-    debugLog.push(`  Balance from movements: $${balance.toLocaleString("es-CL")}`);
-  }
-  if (balance === undefined || balance === 0) {
-    balance = await extractBalance(page);
-  }
 
   debugLog.push(`8. Extracted ${movements.length} movement(s)`);
   progress(`Listo — ${movements.length} movimientos totales`);
@@ -519,7 +875,14 @@ async function scrapeSantander(
   await doSave(page, "05-final");
   const ss = doScreenshots ? ((await page.screenshot({ encoding: "base64", fullPage: true })) as string) : undefined;
 
-  return { success: true, bank, accounts: [{ balance, movements }], screenshot: ss, debug: debugLog.join("\n") };
+  return {
+    success: true,
+    bank,
+    accounts: [{ balance, movements }],
+    creditCards: creditCards?.length ? creditCards : undefined,
+    screenshot: ss,
+    debug: debugLog.join("\n"),
+  };
 }
 
 // ─── Export ──────────────────────────────────────────────────────────

--- a/src/banks/santander.ts
+++ b/src/banks/santander.ts
@@ -322,12 +322,43 @@ function formatCardLabel(cardName?: string, last4?: string): string {
   return `${name} ****${last4}`;
 }
 
-function parseUsdAmount(text?: string | null): number {
-  const clean = (text || "").replace(/[^0-9.,-]/g, "");
-  if (!clean) return 0;
+function extractLast4FromLabel(label: string): string {
+  return label.match(/\*{2,}\s*(\d{4})/)?.[1] ?? "";
+}
+
+/**
+ * Dedup key for credit cards captured while iterating the carousel.
+ *
+ * Swiper can render duplicate ("clone") slides for the same card, so repeats
+ * must collapse. Keying on the last 4 digits keeps genuinely different cards
+ * apart even when they share a product name and identical balances (twin
+ * cards) — the previous label+totals key collapsed those into one. Only when
+ * no last4 is available do we fall back to label+totals.
+ */
+export function creditCardDedupKey(card: CreditCardBalance): string {
+  const last4 = extractLast4FromLabel(card.label);
+  if (last4) return `last4:${last4}`;
+  return `content:${card.label}|${card.national?.total ?? ""}|${card.international?.total ?? ""}`;
+}
+
+export function parseUsdAmount(text?: string | null): number {
+  const raw = (text ?? "").trim();
+  const clean = raw.replace(/[^0-9.,-]/g, "");
   const normalized = clean.replace(/\./g, "").replace(",", ".");
   const amount = Number.parseFloat(normalized);
-  return Number.isNaN(amount) ? 0 : amount;
+  if (Number.isNaN(amount)) {
+    // Santander renders USD amounts in Chilean format ("." thousands, "," decimals).
+    // A non-empty value that fails to parse means the portal likely changed its
+    // display format — warn instead of silently returning 0 so the regression is
+    // visible in logs rather than surfacing as a bogus $0 cupo.
+    if (raw) {
+      console.warn(
+        `[santander] parseUsdAmount: monto USD con formato inesperado, no se pudo parsear "${raw}"`,
+      );
+    }
+    return 0;
+  }
+  return amount;
 }
 
 async function getActiveCreditCardSlideIndex(page: Page): Promise<number> {
@@ -363,6 +394,23 @@ async function listCreditCardSlides(page: Page): Promise<CreditCardSlide[]> {
 
 async function selectCreditCardSlide(page: Page, index: number): Promise<boolean> {
   const clicked = await page.evaluate((targetIndex: number) => {
+    // Preferred: drive the Swiper instance API directly. The live portal
+    // renders no pagination bullets and no "Go to slide" controls, so the
+    // DOM-click fallbacks below are unreliable for actually changing slides;
+    // slideTo / slideToLoop is Swiper's canonical programmatic navigation.
+    const swiperEl = document.querySelector(
+      ".container-carusel .swiper-container, .container-carusel .swiper",
+    ) as (HTMLElement & { swiper?: any }) | null;
+    const swiper = swiperEl?.swiper;
+    if (swiper && typeof swiper.slideTo === "function") {
+      if (swiper.params?.loop && typeof swiper.slideToLoop === "function") {
+        swiper.slideToLoop(targetIndex);
+      } else {
+        swiper.slideTo(targetIndex);
+      }
+      return true;
+    }
+
     const byAria = document.querySelector(
       `.container-carusel [aria-label='Go to slide ${targetIndex + 1}']`,
     ) as HTMLElement | null;
@@ -398,9 +446,61 @@ async function selectCreditCardSlide(page: Page, index: number): Promise<boolean
   return (await getActiveCreditCardSlideIndex(page)) === index;
 }
 
+type RawCreditCardSection = {
+  header: string;
+  available: string | null;
+  used: string | null;
+  total: string | null;
+  currency: string;
+};
+
+type RawCreditCardMetadata = {
+  cardName: string;
+  last4: string;
+  sections: RawCreditCardSection[];
+  billingPeriod: string | null;
+  nextBillingDate: string | null;
+};
+
+/**
+ * Pure transform from the DOM-scraped raw shape into a {@link CreditCardBalance}.
+ * Kept separate from the `page.evaluate` scraping so it can be unit-tested as a
+ * smoke test that at least one card parses correctly without a live browser.
+ */
+export function buildCreditCardFromRaw(raw: RawCreditCardMetadata): CreditCardBalance | null {
+  const label = formatCardLabel(raw.cardName, raw.last4);
+  const card: CreditCardBalance = { label };
+
+  for (const section of raw.sections) {
+    if (!section.available && !section.used && !section.total) continue;
+
+    if (section.currency === "USD") {
+      card.international = {
+        used: Math.abs(parseUsdAmount(section.used)),
+        available: parseUsdAmount(section.available),
+        total: parseUsdAmount(section.total),
+        currency: "USD",
+      };
+      continue;
+    }
+
+    card.national = {
+      used: Math.abs(parseChileanAmount(section.used || "0")),
+      available: parseChileanAmount(section.available || "0"),
+      total: parseChileanAmount(section.total || "0"),
+    };
+  }
+
+  if (!card.national && !card.international) return null;
+  if (raw.billingPeriod) card.billingPeriod = raw.billingPeriod;
+  if (raw.nextBillingDate) card.nextBillingDate = raw.nextBillingDate;
+  return card;
+}
+
 async function extractActiveCreditCardMetadata(page: Page): Promise<CreditCardBalance | null> {
-  const raw = await page.evaluate(() => {
+  const { raw, carouselPresent } = await page.evaluate(() => {
     const normalizeText = (value?: string | null) => value?.replace(/\s+/g, " ").trim() || "";
+    const carouselPresent = !!document.querySelector(".container-carusel");
     const activeSlide = document.querySelector(
       ".container-carusel .swiper-slide.swiper-slide-active",
     ) as HTMLElement | null;
@@ -441,52 +541,42 @@ async function extractActiveCreditCardMetadata(page: Page): Promise<CreditCardBa
         /Pr[oó]xima facturaci[oó]n\s+(\d{1,2}[\/.\-]\d{1,2}(?:[\/.\-]\d{2,4})?|\d{1,2}\s+[A-Za-záéíóúñ]+\s+\d{4})/i,
       )?.[1] || null;
 
-    return { cardName, last4, sections, billingPeriod, nextBillingDate };
+    return { raw: { cardName, last4, sections, billingPeriod, nextBillingDate }, carouselPresent };
   });
 
-  const label = formatCardLabel(raw.cardName, raw.last4);
-  const card: CreditCardBalance = { label };
+  const card = buildCreditCardFromRaw(raw);
 
-  for (const section of raw.sections) {
-    if (!section.available && !section.used && !section.total) continue;
-
-    if (section.currency === "USD") {
-      card.international = {
-        used: Math.abs(parseUsdAmount(section.used)),
-        available: parseUsdAmount(section.available),
-        total: parseUsdAmount(section.total),
-        currency: "USD",
-      };
-      continue;
-    }
-
-    card.national = {
-      used: Math.abs(parseChileanAmount(section.used || "0")),
-      available: parseChileanAmount(section.available || "0"),
-      total: parseChileanAmount(section.total || "0"),
-    };
+  // If the carousel container itself is gone the portal was redesigned; if it's
+  // present but no cupo parsed, the inner `.balance__container` selectors broke.
+  // Either way surface it instead of silently returning a card with no cupo.
+  if (!card) {
+    console.warn(
+      `[santander] no se extrajo cupo de la tarjeta activa ` +
+        `(carrusel=${carouselPresent ? "presente" : "ausente"}, secciones=${raw.sections.length}). ` +
+        `Los selectores del portal pueden haber cambiado.`,
+    );
   }
-
-  if (!card.national && !card.international) return null;
-  if (raw.billingPeriod) card.billingPeriod = raw.billingPeriod;
-  if (raw.nextBillingDate) card.nextBillingDate = raw.nextBillingDate;
   return card;
 }
 
-async function extractCreditCardMetadata(page: Page, debugLog: string[]): Promise<CreditCardBalance[]> {
+/** A captured credit card together with the carousel slide it came from, so the
+ *  statement pass can re-select that slide before reading its billing summary. */
+type CreditCardWithSlide = { card: CreditCardBalance; slideIndex: number };
+
+async function extractCreditCardMetadata(page: Page, debugLog: string[]): Promise<CreditCardWithSlide[]> {
   const slides = await listCreditCardSlides(page);
   const activeIndex = await getActiveCreditCardSlideIndex(page);
   const seen = new Set<string>();
-  const creditCards: CreditCardBalance[] = [];
+  const cards: CreditCardWithSlide[] = [];
 
   const captureCurrentSlide = async (slide: CreditCardSlide | null) => {
     const metadata = await extractActiveCreditCardMetadata(page);
     if (!metadata) return;
 
-    const key = `${metadata.label}|${metadata.national?.total ?? ""}|${metadata.international?.total ?? ""}`;
+    const key = creditCardDedupKey(metadata);
     if (seen.has(key)) return;
     seen.add(key);
-    creditCards.push(metadata);
+    cards.push({ card: metadata, slideIndex: slide ? slide.index : activeIndex });
 
     const national =
       metadata.national
@@ -502,7 +592,7 @@ async function extractCreditCardMetadata(page: Page, debugLog: string[]): Promis
 
   if (slides.length === 0) {
     await captureCurrentSlide(null);
-    return creditCards;
+    return cards;
   }
 
   for (const slide of slides) {
@@ -518,7 +608,7 @@ async function extractCreditCardMetadata(page: Page, debugLog: string[]): Promis
     await selectCreditCardSlide(page, activeIndex);
   }
 
-  return creditCards;
+  return cards;
 }
 
 type LastStatementRaw = {
@@ -799,13 +889,10 @@ async function scrapeSantander(
   // 7b. Credit card movements
   debugLog.push("7b. Navigating to credit card movements...");
   progress("Extrayendo movimientos de tarjeta de crédito...");
-  let creditCards: CreditCardBalance[] | undefined;
+  let cardSlides: CreditCardWithSlide[] = [];
   const tcReady = await navigateToCreditCardSection(page, debugLog);
   if (tcReady) {
-    const metadata = await extractCreditCardMetadata(page, debugLog);
-    if (metadata.length > 0) {
-      creditCards = metadata;
-    }
+    cardSlides = await extractCreditCardMetadata(page, debugLog);
 
     if (await clickTcTab(page, "movimientos por facturar")) {
       const unbilledCaptures = await interceptor.waitFor("santander-credit-card-unbilled", 10_000);
@@ -833,33 +920,52 @@ async function scrapeSantander(
         debugLog.push(`  TC facturados: ${billed.length} movement(s)`);
       }
 
-      if (creditCards && creditCards.length > 0) {
-        // Re-select the "movimientos facturados" tab. The API interception
-        // above captures movements without requiring the UI to stay on the
-        // tab — but the billing summary (statement info) is only rendered
-        // inside that tab's view, and other actions (carousel nav, tab
-        // switching) can push the UI back to "Mi Tarjeta" before we extract.
-        await clickTcTab(page, "movimientos facturados");
-        const rendered = await waitForStatementRender(page);
-        if (!rendered) {
-          debugLog.push(`  Statement anchor text did not appear within 10s`);
-        }
-        const statementRaw = await extractLastStatement(page);
-        const card = creditCards[0];
-        if (applyLastStatement(card, statementRaw)) {
-          debugLog.push(
-            `  Last statement [${card.label}]: billed=$${card.lastStatement!.billedAmount.toLocaleString("es-CL")}, ` +
-            `billingDate=${card.lastStatement!.billingDate}, dueDate=${card.lastStatement!.dueDate}` +
-            (card.lastStatement!.minimumPayment !== undefined
-              ? `, min=$${card.lastStatement!.minimumPayment.toLocaleString("es-CL")}`
-              : ""),
-          );
-        } else {
-          debugLog.push(
-            `  Last statement [${card.label}]: partial (billingDate=${statementRaw.billingDate ?? "—"}, ` +
-            `dueDate=${statementRaw.dueDate ?? "—"}, billed=${statementRaw.billedAmount ?? "—"}, ` +
-            `min=${statementRaw.minimumPayment ?? "—"})`,
-          );
+      if (cardSlides.length > 0) {
+        // Extract the billing summary (statement info) for EVERY credit card,
+        // not just the first. The "movimientos facturados" view only reflects
+        // the card currently selected in the carousel, so we re-select each
+        // card's slide before reading its statement. We track the active slide
+        // so a single-card account never navigates — preserving the originally
+        // verified single-card flow.
+        let currentSlide = await getActiveCreditCardSlideIndex(page);
+        for (const { card, slideIndex } of cardSlides) {
+          if (slideIndex >= 0 && slideIndex !== currentSlide) {
+            if (await selectCreditCardSlide(page, slideIndex)) {
+              currentSlide = slideIndex;
+            } else {
+              debugLog.push(
+                `  Last statement [${card.label}]: no se pudo seleccionar la tarjeta (slide ${slideIndex + 1}), se omite`,
+              );
+              continue;
+            }
+          }
+
+          // The API interception above captures movements without requiring the
+          // UI to stay on the tab, but the statement summary is only rendered
+          // inside the "movimientos facturados" view — and carousel/tab
+          // navigation can push the UI back to "Mi Tarjeta" — so re-open the
+          // tab before each read.
+          await clickTcTab(page, "movimientos facturados");
+          const rendered = await waitForStatementRender(page);
+          if (!rendered) {
+            debugLog.push(`  Statement anchor text did not appear within 10s [${card.label}]`);
+          }
+          const statementRaw = await extractLastStatement(page);
+          if (applyLastStatement(card, statementRaw)) {
+            debugLog.push(
+              `  Last statement [${card.label}]: billed=$${card.lastStatement!.billedAmount.toLocaleString("es-CL")}, ` +
+              `billingDate=${card.lastStatement!.billingDate}, dueDate=${card.lastStatement!.dueDate}` +
+              (card.lastStatement!.minimumPayment !== undefined
+                ? `, min=$${card.lastStatement!.minimumPayment.toLocaleString("es-CL")}`
+                : ""),
+            );
+          } else {
+            debugLog.push(
+              `  Last statement [${card.label}]: partial (billingDate=${statementRaw.billingDate ?? "—"}, ` +
+              `dueDate=${statementRaw.dueDate ?? "—"}, billed=${statementRaw.billedAmount ?? "—"}, ` +
+              `min=${statementRaw.minimumPayment ?? "—"})`,
+            );
+          }
         }
       }
     }
@@ -879,7 +985,7 @@ async function scrapeSantander(
     success: true,
     bank,
     accounts: [{ balance, movements }],
-    creditCards: creditCards?.length ? creditCards : undefined,
+    creditCards: cardSlides.length ? cardSlides.map(({ card }) => card) : undefined,
     screenshot: ss,
     debug: debugLog.join("\n"),
   };


### PR DESCRIPTION
## Qué agrega este PR

Extiende el scraper de Santander para extraer metadata de tarjetas de crédito además de los movimientos que ya captura. Para cada tarjeta en el carousel de tarjetas (página saldos_tc) el scraper ahora obtiene:

- **Cupo** nacional (CLP) e internacional (USD): usado, disponible, total.
- **Próxima fecha de vencimiento** (`nextDueDate`).
- **Período de facturación** (`billingPeriod`), derivado de la fecha real de facturación (ej: "Abril 2026").
- **Último estado de cuenta**: fecha de facturación, monto facturado, fecha de vencimiento y pago mínimo.

Los resultados van bajo el campo `creditCards` de `ScrapeResult` (el tipo `CreditCardBalance` ya estaba definido en `types.ts`). Consumidores que solo leen `accounts` no se ven afectados.

## Cómo funciona

**Cupo (página "Mi Tarjeta"):**
- `listCreditCardSlides` + `selectCreditCardSlide` manejan el carousel con fallbacks de selector (aria-label de dots, bullets de paginación de swiper, click directo al slide).
- `extractActiveCreditCardMetadata` lee `.card-detail .balance__container` y parsea "Disponible / Utilizado / Autorizado".
- Para USD se usa `parseUsdAmount` (coma decimal, punto separador de miles). Para CLP se usa `parseChileanAmount` existente.
- `formatCardLabel` normaliza los nombres a `Nombre ****1234`.

**Último estado (página "Movimientos Facturados"):**
- Tras el click al tab y la espera por la respuesta API, se re-clickea el tab antes de extraer. Sin esto, otras acciones (navegación de carousel, cambios de tab) ocasionalmente devuelven el contenido visible a "Mi Tarjeta" y el resumen desaparece del DOM antes de la extracción.
- `waitForStatementRender` polea hasta 10s esperando que aparezca "Monto total facturado" o "Pagar hasta" en `innerText`.
- `dueDate`, `billedAmount`, `minimumPayment` se leen vía regex sobre `document.body.innerText` con ventanas ajustadas para no cruzar labels adyacentes.
- `billingDate` se lee directamente del dropdown Angular Material (`.mat-select-min-line`), porque su valor seleccionado no se refleja en `innerText` y un regex ingenuo matchearía la fecha vecina de "Pagar hasta".

La resolución del balance de la cuenta corriente se mueve para ocurrir **antes** de navegar a la sección de tarjetas de crédito, simplificando el razonamiento sobre la forma final del retorno.

## Testing

- Probado end-to-end contra una cuenta personal de Santander Chile.
- Validado que los 4 campos del `lastStatement` (billingDate, billedAmount, dueDate, minimumPayment), el `billingPeriod` derivado, `nextDueDate`, y ambos cupos (CLP/USD) se pueblan correctamente. El type-check pasa en los archivos tocados (`npx tsc --noEmit` sobre `santander.ts`).