### PR TITLE
feat(bchile): per-account buckets, movement.account, and since filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1477,8 +1477,7 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -1521,7 +1520,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2043,7 +2041,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2105,7 +2102,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2700,7 +2696,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2729,7 +2724,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/src/banks/bchile.test.ts
+++ b/src/banks/bchile.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { isBchileDepositAccount } from "./bchile.js";
+
+describe("isBchileDepositAccount", () => {
+  it("includes cuenta corriente and vista product types", () => {
+    expect(
+      isBchileDepositAccount({
+        tipo: "cuentaCorrienteMonedaLocal",
+        descripcionLogo: "Cuenta Corriente",
+        numero: "1",
+        mascara: "****2706",
+        codigo: "x",
+        codigoMoneda: "CLP",
+        claseCuenta: "",
+        label: "",
+        tarjetaHabiente: null,
+        tipoCliente: "",
+      }),
+    ).toBe(true);
+
+    expect(
+      isBchileDepositAccount({
+        tipo: "cuentaVistaMonedaLocal",
+        descripcionLogo: "Cuenta Vista",
+        numero: "2",
+        mascara: "****1234",
+        codigo: "y",
+        codigoMoneda: "CLP",
+        claseCuenta: "",
+        label: "",
+        tarjetaHabiente: null,
+        tipoCliente: "",
+      }),
+    ).toBe(true);
+  });
+
+  it("includes products identified by descripcionLogo", () => {
+    expect(
+      isBchileDepositAccount({
+        tipo: "other",
+        descripcionLogo: "Cuenta Vista",
+        numero: "2",
+        mascara: "****1234",
+        codigo: "y",
+        codigoMoneda: "CLP",
+        claseCuenta: "",
+        label: "",
+        tarjetaHabiente: null,
+        tipoCliente: "",
+      }),
+    ).toBe(true);
+  });
+
+  it("excludes credit card products", () => {
+    expect(
+      isBchileDepositAccount({
+        tipo: "tarjetaCredito",
+        descripcionLogo: "Visa Platinum",
+        numero: "3",
+        mascara: "****9999",
+        codigo: "z",
+        codigoMoneda: "CLP",
+        claseCuenta: "",
+        label: "",
+        tarjetaHabiente: null,
+        tipoCliente: "",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/banks/bchile.ts
+++ b/src/banks/bchile.ts
@@ -209,6 +209,28 @@ function accountLabelFromProduct(acct: ApiProduct): string {
   return `${acct.descripcionLogo} ${acct.mascara}`.trim();
 }
 
+/** Deposit accounts to include in cartola fetch (corriente, vista, ahorro, línea de crédito). */
+export function isBchileDepositAccount(product: ApiProduct): boolean {
+  const tipo = (product.tipo || "").toLowerCase();
+  if (
+    tipo === "cuenta" ||
+    tipo === "cuentacorrientemonedalocal" ||
+    tipo === "cuentavistamonedalocal" ||
+    tipo === "cuentaahorromonedalocal"
+  ) {
+    return true;
+  }
+
+  const logo = (product.descripcionLogo || "").toLowerCase();
+  return (
+    logo.includes("cuenta vista") ||
+    logo.includes("cuenta corriente") ||
+    logo.includes("linea de credito")
+  );
+}
+
+const BCHILE_CARTOLA_MAX_PAGES = 100;
+
 function cartolaMovToMovement(mov: ApiCartolaMov, accountLabel: string): BankMovement {
   return {
     date: normalizeDate(mov.fechaContable),
@@ -231,7 +253,7 @@ async function fetchAccountMovements(
   rut: string,
   debugLog: string[],
 ): Promise<AccountBalance[]> {
-  const accounts = products.filter(p => p.tipo === "cuenta" || p.tipo === "cuentaCorrienteMonedaLocal");
+  const accounts = products.filter(isBchileDepositAccount);
   const seenNums = new Set<string>();
   const unique = accounts.filter(a => { if (seenNums.has(a.numero)) return false; seenNums.add(a.numero); return true; });
   if (unique.length === 0) return [];
@@ -259,7 +281,7 @@ async function fetchAccountMovements(
 
         let hasMore = cartola.movimientos.length > 0 && (cartola.pagina?.[0]?.masPaginas ?? false);
         let offset = 1 + cartola.movimientos.length;
-        for (let p = 2; hasMore && p <= 25; p++) {
+        for (let p = 2; hasMore && p <= BCHILE_CARTOLA_MAX_PAGES; p++) {
           try {
             const next = await apiPost<ApiCartolaResponse>(page, "bff-pper-prd-cta-movimientos/movimientos/getCartola", { cuentaSeleccionada, cabecera: { statusGenerico: true, paginacionDesde: offset } });
             if (!next.movimientos?.length) break;
@@ -270,6 +292,8 @@ async function fetchAccountMovements(
         }
       }
     } catch (err) { debugLog.push(`    → Error: ${err instanceof Error ? err.message : String(err)}`); }
+
+    debugLog.push(`  ${label}: ${accountMovements.length} movement(s)`);
 
     buckets.push({
       label,

--- a/src/banks/bchile.ts
+++ b/src/banks/bchile.ts
@@ -1,7 +1,7 @@
 import type { Page } from "puppeteer-core";
-import type { BankMovement, BankScraper, CreditCardBalance, MovementSource, ScrapeResult, ScraperOptions } from "../types.js";
+import type { AccountBalance, BankMovement, BankScraper, CreditCardBalance, MovementSource, ScrapeResult, ScraperOptions } from "../types.js";
 import { MOVEMENT_SOURCE } from "../types.js";
-import { closePopups, delay, formatRut, monthYearLabel, normalizeDate, deduplicateMovements, deduplicateAcrossSources, normalizeInstallments } from "../utils.js";
+import { closePopups, delay, formatRut, monthYearLabel, normalizeDate, deduplicateMovements, deduplicateAcrossSources, normalizeInstallments, filterAccountBucketsSince, filterMovementsSince } from "../utils.js";
 import { runScraper } from "../infrastructure/scraper-runner.js";
 import type { BrowserSession } from "../infrastructure/browser.js";
 import { detect2FA, waitFor2FA } from "../actions/two-factor.js";
@@ -205,38 +205,57 @@ async function bchileLogin(
 
 // ─── Data extraction ─────────────────────────────────────────────
 
-function cartolaMovToMovement(mov: ApiCartolaMov): BankMovement {
-  return { date: normalizeDate(mov.fechaContable), description: mov.descripcion.trim(), amount: mov.tipo === "cargo" ? -Math.abs(mov.monto) : Math.abs(mov.monto), balance: mov.saldo, source: MOVEMENT_SOURCE.account };
+function accountLabelFromProduct(acct: ApiProduct): string {
+  return `${acct.descripcionLogo} ${acct.mascara}`.trim();
+}
+
+function cartolaMovToMovement(mov: ApiCartolaMov, accountLabel: string): BankMovement {
+  return {
+    date: normalizeDate(mov.fechaContable),
+    description: mov.descripcion.trim(),
+    amount: mov.tipo === "cargo" ? -Math.abs(mov.monto) : Math.abs(mov.monto),
+    balance: mov.saldo,
+    source: MOVEMENT_SOURCE.account,
+    account: accountLabel,
+  };
 }
 
 function facturadoToMovement(tx: ApiTransaccionFacturada, source: MovementSource, cardMask?: string): BankMovement {
   return { date: normalizeDate(tx.fechaTransaccionString), description: tx.descripcion.trim(), amount: tx.grupo === "pagos" ? Math.abs(tx.montoTransaccion) : -Math.abs(tx.montoTransaccion), balance: 0, source, card: cardMask, installments: normalizeInstallments(tx.cuotas) };
 }
 
-async function fetchAccountMovements(page: Page, products: ApiProduct[], fullName: string, rut: string, debugLog: string[]): Promise<{ movements: BankMovement[]; balance?: number }> {
+async function fetchAccountMovements(
+  page: Page,
+  products: ApiProduct[],
+  fullName: string,
+  rut: string,
+  debugLog: string[],
+): Promise<AccountBalance[]> {
   const accounts = products.filter(p => p.tipo === "cuenta" || p.tipo === "cuentaCorrienteMonedaLocal");
   const seenNums = new Set<string>();
   const unique = accounts.filter(a => { if (seenNums.has(a.numero)) return false; seenNums.add(a.numero); return true; });
-  if (unique.length === 0) return { movements: [] };
+  if (unique.length === 0) return [];
 
   const baseUrl = page.url().split("#")[0];
   await page.goto(`${baseUrl}#/movimientos/cuenta/saldos-movimientos`, { waitUntil: "networkidle2", timeout: 30000 });
   await delay(5000);
 
-  const movements: BankMovement[] = [];
-  let balance: number | undefined;
+  const buckets: AccountBalance[] = [];
 
   for (const acct of unique) {
-    debugLog.push(`  Fetching ${acct.descripcionLogo} ${acct.mascara}`);
+    const label = accountLabelFromProduct(acct);
+    debugLog.push(`  Fetching ${label}`);
     const cuentaSeleccionada = { nombreCliente: fullName, rutCliente: rut, numero: acct.numero, mascara: acct.mascara, selected: true, codigoProducto: acct.codigo, claseCuenta: acct.claseCuenta, moneda: acct.codigoMoneda };
+    const accountMovements: BankMovement[] = [];
+    let balance: number | undefined;
 
     try {
       await apiPost(page, "movimientos/getConfigConsultaMovimientos", { cuentasSeleccionadas: [cuentaSeleccionada] });
       const cartola = await apiPost<ApiCartolaResponse>(page, "bff-pper-prd-cta-movimientos/movimientos/getCartola", { cuentaSeleccionada, cabecera: { statusGenerico: true, paginacionDesde: 1 } });
 
       if (cartola.movimientos) {
-        for (const mov of cartola.movimientos) movements.push(cartolaMovToMovement(mov));
-        if (balance === undefined && acct.codigoMoneda === "CLP" && cartola.movimientos.length > 0) balance = cartola.movimientos[0].saldo;
+        for (const mov of cartola.movimientos) accountMovements.push(cartolaMovToMovement(mov, label));
+        if (acct.codigoMoneda === "CLP" && cartola.movimientos.length > 0) balance = cartola.movimientos[0].saldo;
 
         let hasMore = cartola.movimientos.length > 0 && (cartola.pagina?.[0]?.masPaginas ?? false);
         let offset = 1 + cartola.movimientos.length;
@@ -244,16 +263,22 @@ async function fetchAccountMovements(page: Page, products: ApiProduct[], fullNam
           try {
             const next = await apiPost<ApiCartolaResponse>(page, "bff-pper-prd-cta-movimientos/movimientos/getCartola", { cuentaSeleccionada, cabecera: { statusGenerico: true, paginacionDesde: offset } });
             if (!next.movimientos?.length) break;
-            for (const mov of next.movimientos) movements.push(cartolaMovToMovement(mov));
+            for (const mov of next.movimientos) accountMovements.push(cartolaMovToMovement(mov, label));
             offset += next.movimientos.length;
             hasMore = next.pagina?.[0]?.masPaginas ?? false;
           } catch { hasMore = false; }
         }
       }
     } catch (err) { debugLog.push(`    → Error: ${err instanceof Error ? err.message : String(err)}`); }
+
+    buckets.push({
+      label,
+      balance,
+      movements: deduplicateMovements(accountMovements),
+    });
   }
 
-  return { movements, balance };
+  return buckets;
 }
 
 async function fetchCreditCardData(page: Page, fullName: string, debugLog: string[]): Promise<{ movements: BankMovement[]; creditCards: CreditCardBalance[] }> {
@@ -417,9 +442,13 @@ async function scrapeBchile(session: BrowserSession, options: ScraperOptions): P
   // Account movements
   debugLog.push("6. Fetching account movements via API...");
   progress("Extrayendo movimientos de cuenta...");
-  const acctResult = await fetchAccountMovements(page, products.productos, fullName, products.rut, debugLog);
-  if (balance === undefined && acctResult.balance !== undefined) balance = acctResult.balance;
-  debugLog.push(`  Account movements: ${acctResult.movements.length}`);
+  let accountBuckets = await fetchAccountMovements(page, products.productos, fullName, products.rut, debugLog);
+  if (balance === undefined) {
+    const clpBucket = accountBuckets.find((bucket) => bucket.balance != null);
+    if (clpBucket?.balance != null) balance = clpBucket.balance;
+  }
+  const accountMovementCount = accountBuckets.reduce((sum, bucket) => sum + bucket.movements.length, 0);
+  debugLog.push(`  Account movements: ${accountMovementCount} across ${accountBuckets.length} account(s)`);
 
   // Credit card data
   debugLog.push("7. Fetching credit card data via API...");
@@ -437,8 +466,18 @@ async function scrapeBchile(session: BrowserSession, options: ScraperOptions): P
   }
 
   const totalTc = tcResult.creditCards.reduce((s, cc) => s + (cc.movements?.length ?? 0), 0);
-  debugLog.push(`8. Total: ${acctResult.movements.length} account + ${totalTc} TC movements`);
-  progress(`Listo — ${acctResult.movements.length + totalTc} movimientos totales`);
+  debugLog.push(`8. Total: ${accountMovementCount} account + ${totalTc} TC movements`);
+  progress(`Listo — ${accountMovementCount + totalTc} movimientos totales`);
+
+  if (options.since) {
+    accountBuckets = filterAccountBucketsSince(accountBuckets, options.since);
+    for (const cc of tcResult.creditCards) {
+      if (cc.movements?.length) {
+        cc.movements = filterMovementsSince(cc.movements, options.since);
+      }
+    }
+    debugLog.push(`  Applied since=${options.since} filter`);
+  }
 
   await doSave(page, "06-final");
   const ss = doScreenshots ? await page.screenshot({ encoding: "base64" }) as string : undefined;
@@ -446,7 +485,7 @@ async function scrapeBchile(session: BrowserSession, options: ScraperOptions): P
   return {
     success: true,
     bank,
-    accounts: [{ balance, movements: deduplicateMovements(acctResult.movements) }],
+    accounts: accountBuckets,
     creditCards: tcResult.creditCards.length > 0 ? tcResult.creditCards : undefined,
     screenshot: ss,
     debug: debugLog.join("\n"),

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,8 @@ export interface BankMovement {
   installments?: string;
   /** Monto total de la compra (distinto de amount cuando es en cuotas) */
   totalAmount?: number;
+  /** Cuenta de origen cuando el titular tiene varios productos (ej: "Cuenta Corriente ****2706") */
+  account?: string;
 }
 
 /** Saldo y movimientos de una cuenta bancaria */
@@ -131,6 +133,11 @@ export interface ScraperOptions extends BankCredentials {
   onProgress?: (step: string) => void;
   /** Callback invocado en cada línea de debug en tiempo real */
   onDebug?: (line: string) => void;
+  /**
+   * Solo importar movimientos posteriores a esta fecha (formato dd-mm-yyyy).
+   * El scraper sigue consultando la cartola completa; el filtro se aplica al resultado.
+   */
+  since?: string;
 }
 
 /** Interfaz que debe implementar cada banco */

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { DebugLog, deduplicateMovements } from "./utils.js";
+import { DebugLog, deduplicateMovements, filterMovementsSince } from "./utils.js";
 import { MOVEMENT_SOURCE } from "./types.js";
 import type { BankMovement } from "./types.js";
 
@@ -116,5 +116,19 @@ describe("deduplicateMovements", () => {
     const b = movement({ description: "B", balance: 200 });
     const result = deduplicateMovements([a, b, a]);
     expect(result.map((m) => m.description)).toEqual(["A", "B"]);
+  });
+});
+
+describe("filterMovementsSince", () => {
+  it("keeps movements strictly after since (dd-mm-yyyy)", () => {
+    const result = filterMovementsSince(
+      [
+        movement({ date: "01-03-2026", description: "old" }),
+        movement({ date: "15-03-2026", description: "new" }),
+      ],
+      "10-03-2026",
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]?.description).toBe("new");
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { Page } from "puppeteer-core";
-import type { BankMovement, CardOwner } from "./types.js";
+import type { AccountBalance, BankMovement, CardOwner } from "./types.js";
 import { CARD_OWNER } from "./types.js";
 
 /**
@@ -170,6 +170,41 @@ export function normalizeDate(raw: string): string {
   }
 
   return value;
+}
+
+/** Convierte DD-MM-YYYY a entero YYYYMMDD para comparaciones. */
+export function chileanDateSortKey(raw: string): number | null {
+  const normalized = normalizeDate(raw);
+  const match = normalized.match(/^(\d{2})-(\d{2})-(\d{4})$/);
+  if (!match) return null;
+  return Number.parseInt(`${match[3]}${match[2]}${match[1]}`, 10);
+}
+
+/** Filtra movimientos con fecha estrictamente posterior a `since` (dd-mm-yyyy). */
+export function filterMovementsSince(
+  movements: BankMovement[],
+  since: string,
+): BankMovement[] {
+  const sinceKey = chileanDateSortKey(since);
+  if (sinceKey == null) return movements;
+
+  return movements.filter((movement) => {
+    const movementKey = chileanDateSortKey(movement.date);
+    if (movementKey == null) return true;
+    return movementKey > sinceKey;
+  });
+}
+
+/** Aplica `since` a cada bucket de cuenta. */
+export function filterAccountBucketsSince(
+  accounts: AccountBalance[],
+  since?: string,
+): AccountBalance[] {
+  if (!since) return accounts;
+  return accounts.map((account) => ({
+    ...account,
+    movements: filterMovementsSince(account.movements, since),
+  }));
 }
 
 // ─── Movements ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Banco de Chile**: `fetchAccountMovements` returns one `AccountBalance` per deposit product (corriente, **vista**, ahorro, línea de crédito) instead of merging cartola rows into a single bucket.
- **Product filter**: `isBchileDepositAccount` includes `cuentaVistaMonedaLocal`, `cuentaAhorroMonedaLocal`, and `descripcionLogo` matches (Cuenta Vista / Cuenta Corriente / Línea de crédito).
- **`BankMovement.account`**: each account movement is tagged with a stable label (e.g. `Cuenta Vista ****1234`).
- **Cartola depth**: up to **100** paginated pages per account (was 25).
- **Debug**: per-account `label: N movement(s)` lines for downstream importers.
- **`ScraperOptions.since`**: optional `dd-mm-yyyy` lower bound; results are filtered after scrape via `filterMovementsSince` / `filterAccountBucketsSince`.

## Motivation

I need separate financial accounts per bank product and an incremental sync cursor. The published `accounts[]` shape existed in types but BChile still collapsed everything into one movement list and skipped Cuenta Vista products.

## Test plan

- [x] `npm test` (67 tests, includes `isBchileDepositAccount`)
- [ ] Manual scrape against BChile with Cuenta Corriente + Cuenta Vista — verify `accounts.length >= 2` and labels match
- [ ] Manual scrape with `since: "01-01-2026"` — verify older movements are excluded