### PR TITLE
fix(falabella): preferir selector #btn-auth sobre match por texto para "Mi cuenta"

### DIFF
--- a/src/banks/falabella.ts
+++ b/src/banks/falabella.ts
@@ -78,11 +78,20 @@ async function login(page: Page, rut: string, password: string, debugLog: string
   } catch { /* no banner */ }
   await screenshotIfEnabled(page, "01-homepage", doScreenshots, debugLog);
 
-  // Click "Mi cuenta" (triggers navigation)
+  // Click "Mi cuenta" (triggers navigation).
+  // The homepage has 3 elements with text "Mi cuenta": a loan-calculator button
+  // (first in DOM, NOT the login), and the real login buttons #btn-auth-normal
+  // (desktop) and #btn-auth (responsive). Prefer the specific IDs; only fall
+  // back to text matching if neither is visible.
   debugLog.push("2. Clicking 'Mi cuenta'...");
   progress("Ingresando a Mi cuenta...");
   try {
-    await page.locator('a, button').filter({ hasText: "Mi cuenta" }).first().click({ timeout: 5000 });
+    const authBtn = page.locator('#btn-auth-normal, #btn-auth').first();
+    if (await authBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await authBtn.click({ timeout: 5000 });
+    } else {
+      await page.locator('a, button').filter({ hasText: "Mi cuenta" }).first().click({ timeout: 5000 });
+    }
   } catch { /* may cause navigation context change */ }
   await page.waitForLoadState("networkidle").catch(() => {});
   await delay(3000);


### PR DESCRIPTION
## Contexto
Cierra #71. Diagnóstico completo en [este comentario del issue](https://github.com/kaihv/open-banking-chile/issues/71#issuecomment-4617974974).

## Causa raíz
El homepage de `bancofalabella.cl` tiene 3 elementos con texto "Mi cuenta":

1. Un `<button>` sin id, asociado a la calculadora de créditos (primero en el DOM).
2. `<button id="btn-auth-normal">` — login real (desktop).
3. `<button id="btn-auth">` — login real (responsive).

`page.locator('a, button').filter({ hasText: "Mi cuenta" }).first()` matchea el primero (calculadora). El click sobre ese elemento gatilla un re-render que destruye el contexto JS justo cuando Playwright/Puppeteer intenta resolver el click → `Execution context was destroyed, most likely because of a navigation`. Si uno traga ese error, el flujo continúa pero `fillRut` rellena el RUT en la calculadora de créditos y `fillPassword` ya no encuentra `#pass` porque el modal de login nunca se abrió.

## Fix
Probar primero los selectores específicos `#btn-auth-normal, #btn-auth`. Solo caer al match por texto si ninguno está visible (compatibilidad con cambios futuros del sitio).

## Verificación
Reproducido contra el sitio real con `open-banking-chile@2.1.2`: sin el fix, falla con el error del issue; con el fix aplicado al `dist` el flujo avanza al modal de login correctamente.