### PR TITLE
fix: habilitar sandbox de Chrome por defecto

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ Campos opcionales en `BankMovement`:
 - No hay analytics, telemetría, ni tracking.
 - Las credenciales se pasan por env vars, nunca se guardan en disco.
 - Los screenshots de debug pueden contener datos sensibles — no los compartas.
+- Chrome corre con su sandbox activo por defecto. Si ejecutas Node como root (Docker/CI), el proyecto agrega `--no-sandbox` automáticamente porque Chrome lo requiere, pero eso reduce el aislamiento del proceso.
+- En producción, prefiere correr el scraper con un usuario no-root.
 - Lee [SECURITY.md](SECURITY.md) para más detalles.
 
 ## Arquitectura
@@ -297,6 +299,7 @@ src/
   cli.ts                      — CLI entry point
   infrastructure/
     browser.ts                — Gestión centralizada del browser (launch, sesión, cleanup)
+    chrome-args.ts            — Flags compartidos de Chrome y sandbox root/no-root
     scraper-runner.ts         — Pipeline de ejecución (credenciales → browser → scrape → logout → resultado)
   actions/
     login.ts                  — Login genérico (RUT, password, submit, detección de errores)
@@ -381,6 +384,7 @@ interface BankScraper {
 | Problema              | Solución                                                                                       |
 | --------------------- | ---------------------------------------------------------------------------------------------- |
 | Chrome no encontrado  | Instala Chrome o usa `CHROME_PATH=/ruta/chrome`                                                |
+| Chrome sin sandbox    | Solo se usa automáticamente si Node corre como root. En producción usa un usuario no-root       |
 | 2FA / Clave dinámica  | Si aparece, apruébalo manualmente en tu banco y vuelve a intentar                              |
 | 0 movimientos         | Usa `--screenshots --pretty` y revisa el debug log                                             |
 | Login falla           | Verifica RUT y clave, prueba con `--headful`                                                   |
@@ -420,9 +424,13 @@ xvfb-run node tu-app.js
 **En Docker:**
 
 ```dockerfile
-RUN apt-get update && apt-get install -y xvfb google-chrome-stable
+RUN apt-get update && apt-get install -y xvfb google-chrome-stable \
+  && useradd -m scraper
+USER scraper
 CMD ["xvfb-run", "node", "server.js"]
 ```
+
+Si corres el contenedor como root, Chrome se iniciará con `--no-sandbox` para poder abrir. Funciona, pero es menos aislado que usar un usuario no-root.
 
 **En Mac/Windows** no necesitas nada extra — Chrome se abre y cierra automáticamente.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,7 @@ Este proyecto maneja credenciales bancarias. La seguridad no es negociable.
 - **NUNCA** se envían credenciales ni datos a servidores externos
 - El scraper solo se comunica con el portal oficial del banco
 - No hay analytics, telemetría, ni tracking de ningún tipo
+- Chrome corre con sandbox activo salvo cuando Node corre como root; en ese caso se usan flags `--no-sandbox` porque Chrome lo exige, pero se recomienda correr como usuario no-root.
 
 ### 2. Credenciales en memoria, nunca en disco
 - Las credenciales se pasan via variables de entorno o parámetros
@@ -48,3 +49,4 @@ Responderemos dentro de 48 horas.
 - **2FA**: Si tu banco pide clave dinámica, el scraper no puede proceder. Esto es intencional — no intentamos bypassear seguridad bancaria.
 - **Sesiones**: No persistimos sesiones. Cada ejecución hace login completo.
 - **Rate limiting**: Si ejecutas el scraper muchas veces seguidas, el banco puede bloquear tu cuenta temporalmente. Recomendamos máximo 1 ejecución por hora.
+- **Chrome como root**: En Docker/CI root, Chrome puede necesitar `--no-sandbox`. Es compatible, pero menos aislado que correr el proceso con un usuario no-root.

--- a/src/banks/falabella.ts
+++ b/src/banks/falabella.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { chromium, type Browser, type Page } from "playwright-core";
+import { buildChromeArgs, getChromeSandboxWarning } from "../infrastructure/chrome-args.js";
 import type { BankMovement, BankScraper, CreditCardBalance, MovementSource, ScrapeResult, ScraperOptions } from "../types.js";
 import { MOVEMENT_SOURCE } from "../types.js";
 import { DebugLog, delay, deduplicateAcrossSources, deduplicateMovements, findChrome, monthYearLabel, normalizeDate, normalizeOwner, normalizeInstallments, parseChileanAmount } from "../utils.js";
@@ -16,6 +17,8 @@ const CMR_WAIT_MS = 30_000;
 async function launchPlaywright(options: ScraperOptions): Promise<{ browser: Browser; page: Page; debugLog: string[] }> {
   const { chromePath, headful, onDebug } = options;
   const debugLog: string[] = onDebug ? new DebugLog(onDebug) : [];
+  const sandboxWarning = getChromeSandboxWarning();
+  if (sandboxWarning) debugLog.push(`  ${sandboxWarning}`);
 
   const execPath = findChrome(chromePath);
   if (!execPath) {
@@ -29,14 +32,7 @@ async function launchPlaywright(options: ScraperOptions): Promise<{ browser: Bro
   const browser = await chromium.launch({
     executablePath: execPath,
     headless: !headful,
-    args: [
-      "--no-sandbox",
-      "--disable-setuid-sandbox",
-      "--disable-dev-shm-usage",
-      "--disable-gpu",
-      "--disable-blink-features=AutomationControlled",
-      "--disable-notifications",
-    ],
+    args: buildChromeArgs({ includeWindowSize: false, extraArgs: ["--disable-notifications"] }),
   });
 
   const context = await browser.newContext({

--- a/src/infrastructure/browser.ts
+++ b/src/infrastructure/browser.ts
@@ -1,5 +1,6 @@
 import puppeteer, { type Browser, type Page } from "puppeteer-core";
 import { DebugLog, findChrome, saveScreenshot } from "../utils.js";
+import { buildChromeArgs, getChromeSandboxWarning } from "./chrome-args.js";
 
 export interface BrowserOptions {
   chromePath?: string;
@@ -19,15 +20,6 @@ export interface BrowserSession {
   /** Save a named screenshot (noop if screenshots disabled) */
   screenshot: (page: Page, name: string) => Promise<void>;
 }
-
-const DEFAULT_ARGS = [
-  "--no-sandbox",
-  "--disable-setuid-sandbox",
-  "--disable-dev-shm-usage",
-  "--disable-gpu",
-  "--window-size=1280,900",
-  "--disable-blink-features=AutomationControlled",
-];
 
 const DEFAULT_UA =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
@@ -56,6 +48,8 @@ export async function launchBrowser(
 ): Promise<BrowserSession> {
   const { chromePath, headful, forceHeadful, extraArgs, viewport, onDebug } = options;
   const debugLog: string[] = onDebug ? new DebugLog(onDebug) : [];
+  const sandboxWarning = getChromeSandboxWarning();
+  if (sandboxWarning) debugLog.push(`  ${sandboxWarning}`);
 
   // Some banks (e.g. BancoEstado) block headless browsers via TLS fingerprinting
   // and require a visible Chrome window. On Linux this needs a display server.
@@ -81,7 +75,7 @@ export async function launchBrowser(
   const browser = await puppeteer.launch({
     executablePath,
     headless: forceHeadful ? false : !headful,
-    args: [...DEFAULT_ARGS, ...(extraArgs || [])],
+    args: buildChromeArgs({ extraArgs }),
   });
 
   const page = await browser.newPage();

--- a/src/infrastructure/chrome-args.test.ts
+++ b/src/infrastructure/chrome-args.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildChromeArgs,
+  getChromeSandboxArgs,
+  getChromeSandboxWarning,
+  isRootProcess,
+  type RuntimeInfo,
+} from "./chrome-args.js";
+
+const linuxUser: RuntimeInfo = { platform: "linux", getuid: () => 1000 };
+const linuxRoot: RuntimeInfo = { platform: "linux", getuid: () => 0 };
+const macUser: RuntimeInfo = { platform: "darwin", getuid: () => 501 };
+const windowsRuntime: RuntimeInfo = { platform: "win32", getuid: () => 0 };
+const unknownUid: RuntimeInfo = { platform: "linux" };
+
+describe("chrome args", () => {
+  it("mantiene el sandbox de Chrome para usuarios normales", () => {
+    const args = buildChromeArgs({ runtime: linuxUser });
+
+    expect(args).not.toContain("--no-sandbox");
+    expect(args).not.toContain("--disable-setuid-sandbox");
+    expect(args).toContain("--disable-dev-shm-usage");
+    expect(args).toContain("--disable-gpu");
+    expect(args).toContain("--window-size=1280,900");
+    expect(args).toContain("--disable-blink-features=AutomationControlled");
+  });
+
+  it("desactiva el sandbox solo cuando el proceso corre como root", () => {
+    const args = buildChromeArgs({ runtime: linuxRoot });
+
+    expect(args.slice(0, 2)).toEqual(["--no-sandbox", "--disable-setuid-sandbox"]);
+  });
+
+  it("no asume root en Windows aunque exista getuid", () => {
+    expect(isRootProcess(windowsRuntime)).toBe(false);
+    expect(getChromeSandboxArgs(windowsRuntime)).toEqual([]);
+  });
+
+  it("no desactiva el sandbox si el runtime no expone getuid", () => {
+    expect(isRootProcess(unknownUid)).toBe(false);
+    expect(buildChromeArgs({ runtime: unknownUid })).not.toContain("--no-sandbox");
+  });
+
+  it("permite omitir window-size para launchers que configuran viewport aparte", () => {
+    const args = buildChromeArgs({ includeWindowSize: false, runtime: macUser });
+
+    expect(args).not.toContain("--window-size=1280,900");
+  });
+
+  it("agrega extraArgs sin cambiar la política de sandbox por defecto", () => {
+    const args = buildChromeArgs({
+      runtime: linuxUser,
+      extraArgs: ["--disable-notifications"],
+    });
+
+    expect(args).toContain("--disable-notifications");
+    expect(args).not.toContain("--no-sandbox");
+  });
+
+  it("avisa cuando Chrome se va a iniciar sin sandbox", () => {
+    expect(getChromeSandboxWarning(linuxUser)).toBeNull();
+    expect(getChromeSandboxWarning(linuxRoot)).toContain("root");
+    expect(getChromeSandboxWarning(linuxRoot)).toContain("sin sandbox");
+  });
+});

--- a/src/infrastructure/chrome-args.ts
+++ b/src/infrastructure/chrome-args.ts
@@ -1,0 +1,49 @@
+export interface RuntimeInfo {
+  platform: string;
+  getuid?: () => number;
+}
+
+export interface ChromeArgsOptions {
+  extraArgs?: string[];
+  includeWindowSize?: boolean;
+  runtime?: RuntimeInfo;
+}
+
+const SANDBOX_DISABLED_ARGS = ["--no-sandbox", "--disable-setuid-sandbox"];
+
+function currentRuntime(): RuntimeInfo {
+  return {
+    platform: process.platform,
+    getuid: typeof process.getuid === "function" ? process.getuid.bind(process) : undefined,
+  };
+}
+
+export function isRootProcess(runtime: RuntimeInfo = currentRuntime()): boolean {
+  return runtime.platform !== "win32" && typeof runtime.getuid === "function" && runtime.getuid() === 0;
+}
+
+export function getChromeSandboxArgs(runtime?: RuntimeInfo): string[] {
+  return isRootProcess(runtime) ? [...SANDBOX_DISABLED_ARGS] : [];
+}
+
+export function getChromeSandboxWarning(runtime?: RuntimeInfo): string | null {
+  if (!isRootProcess(runtime)) return null;
+
+  return "Aviso: el proceso corre como root; Chrome se iniciará sin sandbox. En producción conviene correr el scraper con un usuario no-root.";
+}
+
+export function buildChromeArgs(options: ChromeArgsOptions = {}): string[] {
+  const { extraArgs = [], includeWindowSize = true, runtime } = options;
+  const args = [
+    ...getChromeSandboxArgs(runtime),
+    "--disable-dev-shm-usage",
+    "--disable-gpu",
+  ];
+
+  if (includeWindowSize) {
+    args.push("--window-size=1280,900");
+  }
+
+  args.push("--disable-blink-features=AutomationControlled", ...extraArgs);
+  return args;
+}


### PR DESCRIPTION
## Qué cambia

- Centraliza los flags de Chrome en `src/infrastructure/chrome-args.ts`.
- Mantiene el sandbox activo para usuarios normales y solo agrega `--no-sandbox` / `--disable-setuid-sandbox` cuando Node corre como root.
- Aplica la misma lógica al launcher central de Puppeteer y al launcher Playwright de Falabella.
- Documenta el riesgo root/Docker en `README.md` y `SECURITY.md`.
- Agrega tests unitarios para Linux root/no-root, Windows y `extraArgs`.

## Por qué

Resuelve #33. Antes los flags sin sandbox se aplicaban siempre desde `src/infrastructure/browser.ts`, y Falabella además tenía su propio `chromium.launch()` con los mismos flags hardcodeados. Eso dejaba Chrome sin sandbox incluso en ejecuciones normales de usuario.

## Validación

- `npm test` → 70 tests passed
- `npm run build` → OK
- `git diff --check` → OK