### PR TITLE
bchile: tag account movements with their account máscara

### DIFF
--- a/src/banks/bchile.ts
+++ b/src/banks/bchile.ts
@@ -205,8 +205,8 @@ async function bchileLogin(
 
 // ─── Data extraction ─────────────────────────────────────────────
 
-function cartolaMovToMovement(mov: ApiCartolaMov): BankMovement {
-  return { date: normalizeDate(mov.fechaContable), description: mov.descripcion.trim(), amount: mov.tipo === "cargo" ? -Math.abs(mov.monto) : Math.abs(mov.monto), balance: mov.saldo, source: MOVEMENT_SOURCE.account };
+function cartolaMovToMovement(mov: ApiCartolaMov, account?: string): BankMovement {
+  return { date: normalizeDate(mov.fechaContable), description: mov.descripcion.trim(), amount: mov.tipo === "cargo" ? -Math.abs(mov.monto) : Math.abs(mov.monto), balance: mov.saldo, source: MOVEMENT_SOURCE.account, ...(account ? { account } : {}) };
 }
 
 function facturadoToMovement(tx: ApiTransaccionFacturada, source: MovementSource, cardMask?: string): BankMovement {
@@ -235,7 +235,7 @@ async function fetchAccountMovements(page: Page, products: ApiProduct[], fullNam
       const cartola = await apiPost<ApiCartolaResponse>(page, "bff-pper-prd-cta-movimientos/movimientos/getCartola", { cuentaSeleccionada, cabecera: { statusGenerico: true, paginacionDesde: 1 } });
 
       if (cartola.movimientos) {
-        for (const mov of cartola.movimientos) movements.push(cartolaMovToMovement(mov));
+        for (const mov of cartola.movimientos) movements.push(cartolaMovToMovement(mov, acct.mascara));
         if (balance === undefined && acct.codigoMoneda === "CLP" && cartola.movimientos.length > 0) balance = cartola.movimientos[0].saldo;
 
         let hasMore = cartola.movimientos.length > 0 && (cartola.pagina?.[0]?.masPaginas ?? false);
@@ -244,7 +244,7 @@ async function fetchAccountMovements(page: Page, products: ApiProduct[], fullNam
           try {
             const next = await apiPost<ApiCartolaResponse>(page, "bff-pper-prd-cta-movimientos/movimientos/getCartola", { cuentaSeleccionada, cabecera: { statusGenerico: true, paginacionDesde: offset } });
             if (!next.movimientos?.length) break;
-            for (const mov of next.movimientos) movements.push(cartolaMovToMovement(mov));
+            for (const mov of next.movimientos) movements.push(cartolaMovToMovement(mov, acct.mascara));
             offset += next.movimientos.length;
             hasMore = next.pagina?.[0]?.masPaginas ?? false;
           } catch { hasMore = false; }

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ export interface BankMovement {
   owner?: CardOwner;
   /** Identificador de la tarjeta (ej: "****8335") — útil cuando hay múltiples tarjetas */
   card?: string;
+  /** Máscara de la cuenta de origen (ej: "****8717") — útil cuando hay múltiples cuentas */
+  account?: string;
   /** Cuotas (ej: "01/01", "02/06") */
   installments?: string;
   /** Monto total de la compra (distinto de amount cuando es en cuotas) */


### PR DESCRIPTION
En `fetchAccountMovements` (Banco de Chile) se itera sobre cada cuenta corriente pero todos los movimientos se acumulan en una sola lista sin registrar de qué cuenta proviene cada uno. Con múltiples cuentas corrientes no es posible distinguir los movimientos: la `acct.mascara` (ej. `****8717`) está disponible al momento del push pero se descarta.

## Cambio

- Se agrega el campo opcional `account?: string` a `BankMovement` (mismo patrón que el `card?` existente).
- Se pasa `acct.mascara` a `cartolaMovToMovement`, de modo que cada movimiento de cuenta queda etiquetado con su máscara.

Solo afecta a `bchile`; los demás bancos omiten el campo igual que omiten `card` hoy. El campo es opcional y aditivo, así que los consumidores existentes no se ven afectados.

## Prueba

Verificado contra una cuenta real con 3 cuentas corrientes: los movimientos ahora incluyen `"account": "****8717"` / `"****5808"` y se agrupan correctamente por cuenta. La cuenta sin movimientos del periodo simplemente no aparece.