### PR TITLE
fix: preserve decimal cents in parseChileanAmount (USD amounts)

### DIFF
--- a/src/banks/santander.test.ts
+++ b/src/banks/santander.test.ts
@@ -199,6 +199,19 @@ describe("normalizeSantanderUnbilledApiMovements", () => {
     expect(result[0].balance).toBe(0);
   });
 
+  it("keeps USD cents (comma decimals) instead of truncating to whole dollars", () => {
+    const capture = {
+      DATA: {
+        MatrizMovimientos: [
+          { Fecha: "02/06/2026", Comercio: "Netflix.com", Descripcion: "", Importe: "14,82", IndicadorDebeHaber: "D" },
+        ],
+      },
+    };
+    const result = normalizeSantanderUnbilledApiMovements([capture]);
+    expect(result).toHaveLength(1);
+    expect(result[0].amount).toBe(-14.82);
+  });
+
   it("parses a credit movement (IndicadorDebeHaber=H)", () => {
     const capture = {
       DATA: {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,7 +1,29 @@
 import { describe, it, expect, vi } from "vitest";
-import { DebugLog, deduplicateMovements } from "./utils.js";
+import { DebugLog, deduplicateMovements, parseChileanAmount } from "./utils.js";
 import { MOVEMENT_SOURCE } from "./types.js";
 import type { BankMovement } from "./types.js";
+
+// ─── parseChileanAmount ──────────────────────────────────────────
+
+describe("parseChileanAmount", () => {
+  it("parses CLP amounts (dots = thousands) as integers", () => {
+    expect(parseChileanAmount("$1.234.567")).toBe(1234567);
+    expect(parseChileanAmount("-$50.000")).toBe(-50000);
+    expect(parseChileanAmount("15.990")).toBe(15990);
+  });
+
+  it("keeps decimal cents (comma = decimal), e.g. USD amounts", () => {
+    expect(parseChileanAmount("13,99")).toBe(13.99);
+    expect(parseChileanAmount("USD 14,82")).toBe(14.82);
+    expect(parseChileanAmount("-$1.234,56")).toBe(-1234.56);
+  });
+
+  it("handles negatives and empty/garbage input", () => {
+    expect(parseChileanAmount("-14,82")).toBe(-14.82);
+    expect(parseChileanAmount("")).toBe(0);
+    expect(parseChileanAmount("abc")).toBe(0);
+  });
+});
 
 // ─── DebugLog ────────────────────────────────────────────────────
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,8 +115,12 @@ export const MONTHS_MAP: Record<string, string> = {
 };
 
 /**
- * Parsea un monto en formato chileno a número entero.
- * Maneja: "$1.234.567", "-$50.000", "$1.234,56" (CLP con decimales).
+ * Parsea un monto en formato chileno a número.
+ * Maneja: "$1.234.567", "-$50.000", "$1.234,56", "USD 13,99".
+ *
+ * Conserva los decimales (centavos) cuando existen — necesario para montos en
+ * USD como "13,99". Los montos en CLP son enteros y no se ven afectados (el
+ * redondeo a 2 decimales sólo evita ruido de punto flotante).
  */
 export function parseChileanAmount(text: string): number {
   const clean = text.replace(/[^0-9.,-]/g, "");
@@ -124,7 +128,8 @@ export function parseChileanAmount(text: string): number {
   const isNegative = clean.startsWith("-") || text.includes("-$");
   // Remove thousand separators (dots), convert decimal comma to dot
   const normalized = clean.replace(/-/g, "").replace(/\./g, "").replace(",", ".");
-  const amount = parseInt(normalized, 10) || 0;
+  // parseFloat (not parseInt) so decimal amounts keep their cents.
+  const amount = Math.round((parseFloat(normalized) || 0) * 100) / 100;
   return isNegative ? -amount : amount;
 }
 


### PR DESCRIPTION
## Problem

`parseChileanAmount` parses with `parseInt`, which truncates the decimal part:

```ts
const amount = parseInt(normalized, 10) || 0;   // "14,82" -> 14
```

For CLP that's correct (whole pesos), but it silently drops the **cents on USD amounts**. In practice, USD credit-card movements (Santander WORLDMEMBER, "no facturados") come through as whole-dollar integers — e.g. a `14,82` charge is stored as `14`. The tell-tale sign is that every USD movement lands exactly on a whole dollar, which real charges essentially never do.

This is also inconsistent with the existing handling of USD **cupo** (used/available/total), which already preserves cents via `Math.round(parseFloat(...) * 100) / 100`.

## Fix

Use `parseFloat` instead of `parseInt`, rounded to 2 decimals to avoid floating-point noise:

```ts
const amount = Math.round((parseFloat(normalized) || 0) * 100) / 100;
```

- CLP amounts are whole numbers and are unaffected (e.g. `"15.990"` -> `15990`).
- USD amounts keep their cents (e.g. `"14,82"` -> `14.82`).

## Tests

- New `parseChileanAmount` unit tests (CLP integers, USD cents, negatives, garbage input).
- New Santander unbilled-movement test asserting USD cents are preserved.
- Full suite green: 67 passed.