### PR TITLE
Agrega scraper de BCI Pyme (Banca Empresas)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ BICE_RUT=123456789
 SANTANDER_RUT=123456789
 EDWARDS_RUT=123456789
 BCI_RUT=123456789
+BCIPYME_RUT=123456789
 ITAU_RUT=123456789
 BANCOCHILE_RUT=123456789
 BCHILE_RUT=123456789
@@ -19,6 +20,7 @@ BICE_PASS=tu_clave_aqui
 SANTANDER_PASS=tu_clave_aqui
 EDWARDS_PASS=tu_clave_aqui
 BCI_PASS=tu_clave_aqui
+BCIPYME_PASS=tu_clave_aqui
 ITAU_PASS=tu_clave_aqui
 BANCOCHILE_PASS=tu_clave_aqui
 BCHILE_PASS=tu_clave_aqui
@@ -36,6 +38,8 @@ CENCOSUD_PASS=tu_clave_aqui
 # SANTANDER_2FA_TIMEOUT_SEC=240
 # Opcional [BCI]: segundos máximos para esperar aprobación manual de 2FA (default: 180)
 # BCI_2FA_TIMEOUT_SEC=240
+# Opcional [BCIPYME]: segundos máximos para esperar aprobación manual de 2FA (default: 180)
+# BCIPYME_2FA_TIMEOUT_SEC=240
 # Opcional [ITAU]: segundos máximos para esperar aprobación manual de 2FA Itaú Key (default: 180)
 # ITAU_2FA_TIMEOUT_SEC=240
 # Opcional [BICE]: cantidad de periodos historicos adicionales a consultar (default: 0 = solo mes actual). Debe ser un valor entre 1 y 16

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ También en esta versión: utilidades compartidas (`parseChileanAmount`, `normal
 | Scotiabank                        | `scotiabank` | ✅ Funcional |
 | Banco de Chile                    | `bchile`     | ✅ Funcional |
 | BCI                               | `bci`        | ✅ Funcional |
+| BCI Pyme (Banca Empresas)         | `bcipyme`    | ✅ Funcional |
 | Itaú                              | `itau`       | ✅ Funcional |
 | Banco Estado (CuentaRUT)          | `bestado`    | ✅ Funcional |
 | Tarjeta Cencosud                  | `cencosud`   | ✅ Funcional |
@@ -118,6 +119,10 @@ EDWARDS_PASS=tu_clave
 # Itaú
 ITAU_RUT=12345678-9
 ITAU_PASS=tu_clave
+
+# BCI Pyme (Banca Empresas)
+BCIPYME_RUT=12345678-9
+BCIPYME_PASS=tu_clave
 
 # Banco Estado
 BESTADO_RUT=12345678-9
@@ -311,6 +316,7 @@ src/
     bestado.ts                — Banco Estado (CuentaRUT, requiere headful)
     bchile.ts                 — Banco de Chile
     bci.ts                    — BCI (iframes + BCI Pass)
+    bci-pyme.ts               — BCI Pyme / Banca Empresas (portal OSS, API JSON)
     bice.ts                   — Banco BICE
     cencosud.ts               — Tarjeta Cencosud (hCaptcha intermitente, requiere --headful si aparece)
     edwards.ts                — Banco Edwards
@@ -386,6 +392,27 @@ interface BankScraper {
 | Login falla           | Verifica RUT y clave, prueba con `--headful`                                                   |
 | BancoEstado bloqueado | BancoEstado bloquea headless (TLS fingerprinting). Siempre abre Chrome visible. Ver nota abajo |
 | Cencosud pide CAPTCHA | Ocurre ocasionalmente. En headless retorna error — reintenta con `--headful` para resolverlo manualmente |
+
+### BCI Pyme (Banca Empresas)
+
+`bcipyme` es independiente de `bci` (personas): apunta al portal Pyme
+(`banco-en-linea/pyme`), que tras el login redirige al portal OSS
+(`oss.bci.cl`), una SPA alimentada por una API REST JSON. El scraper
+intercepta la API en lugar de raspar tablas:
+
+- Cuentas y saldos desde `ms-oss-cuentas/v2/cuentas`.
+- Movimientos desde `bff-oss-resumen-cta/.../cuentas/movimientos`. La UI
+  solo solicita los últimos 100 movimientos; el scraper captura esa
+  request y la re-ejecuta con un rango amplio para traer todo el
+  historial disponible (varios años, según la antigüedad de la cuenta).
+
+```bash
+node dist/cli.js --bank bcipyme --pretty
+```
+
+> Probado con un perfil de **una sola cuenta corriente**. El soporte
+> multi-cuenta está implementado (prefija la descripción con la cuenta de
+> origen) pero aún no validado contra un login Pyme con varias cuentas.
 
 ### BancoEstado y modo headless
 

--- a/src/banks/bci-pyme.test.ts
+++ b/src/banks/bci-pyme.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { MOVEMENT_SOURCE } from "../types.js";
+import { normalizeMovements, isoToDate } from "./bci-pyme.js";
+
+describe("isoToDate", () => {
+  it("converts YYYY-MM-DD to dd-mm-yyyy", () => {
+    expect(isoToDate("2026-06-19")).toBe("19-06-2026");
+  });
+
+  it("ignores a trailing time portion", () => {
+    expect(isoToDate("2026-06-19T11:04:00")).toBe("19-06-2026");
+  });
+
+  it("passes through unrecognized formats unchanged", () => {
+    expect(isoToDate("06/19/2026")).toBe("06/19/2026");
+  });
+});
+
+describe("normalizeMovements", () => {
+  it("returns empty array when there are no movimientos", () => {
+    expect(normalizeMovements({})).toEqual([]);
+    expect(normalizeMovements({ movimientos: [] })).toEqual([]);
+  });
+
+  it("parses a cargo (tipo=C → negative amount) using fechaContable", () => {
+    const result = normalizeMovements({
+      movimientos: [
+        { fechaMovimiento: "06/19/2026", fechaContable: "2026-06-19", descripcion: "Pago proveedor demo", monto: "12345.0000", saldoContable: 1000000, tipo: "C" },
+      ],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].amount).toBe(-12345);
+    expect(result[0].date).toBe("19-06-2026");
+    expect(result[0].description).toBe("Pago proveedor demo");
+    expect(result[0].balance).toBe(1000000);
+    expect(result[0].source).toBe(MOVEMENT_SOURCE.account);
+  });
+
+  it("parses an abono (tipo=A → positive amount)", () => {
+    const result = normalizeMovements({
+      movimientos: [
+        { fechaContable: "2026-06-15", descripcion: "Abono demo", monto: "50000.0000", saldoContable: 1050000, tipo: "A" },
+      ],
+    });
+    expect(result[0].amount).toBe(50000);
+    expect(result[0].amount).toBeGreaterThan(0);
+  });
+
+  it("rounds fractional montos to the nearest integer", () => {
+    const result = normalizeMovements({
+      movimientos: [{ fechaContable: "2026-01-01", descripcion: "x", monto: "1499.9", tipo: "C" }],
+    });
+    expect(result[0].amount).toBe(-1500);
+  });
+
+  it("skips movements with zero or NaN monto", () => {
+    const result = normalizeMovements({
+      movimientos: [
+        { fechaContable: "2026-01-01", descripcion: "zero", monto: "0", tipo: "C" },
+        { fechaContable: "2026-01-01", descripcion: "nan", monto: "abc", tipo: "A" },
+      ],
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  it("defaults balance to 0 when saldoContable is missing", () => {
+    const result = normalizeMovements({
+      movimientos: [{ fechaContable: "2026-01-01", descripcion: "x", monto: "1000", tipo: "A" }],
+    });
+    expect(result[0].balance).toBe(0);
+  });
+});

--- a/src/banks/bci-pyme.ts
+++ b/src/banks/bci-pyme.ts
@@ -1,0 +1,370 @@
+import type { Page, HTTPResponse } from "puppeteer-core";
+import type { AccountBalance, BankMovement, BankScraper, ScrapeResult, ScraperOptions } from "../types.js";
+import { MOVEMENT_SOURCE } from "../types.js";
+import { closePopups, delay, formatRut, deduplicateMovements } from "../utils.js";
+import { runScraper } from "../infrastructure/scraper-runner.js";
+import type { BrowserSession } from "../infrastructure/browser.js";
+import { detect2FA, waitFor2FA } from "../actions/two-factor.js";
+import { detectLoginError } from "../actions/login.js";
+
+// ─── BCI Pyme constants ──────────────────────────────────────────
+//
+// El portal Pyme NO usa el sitio de "personas". Tras el login redirige al
+// nuevo portal OSS (oss.bci.cl), una SPA embebida en un iframe de
+// bel.bci.cl que se alimenta de una API REST JSON. En vez de raspar tablas
+// HTML, interceptamos la API:
+//   - POST ms-oss-cuentas/v2/cuentas              → cuentas + saldos
+//   - POST bff-oss-resumen-cta/vX/cuentas/movimientos → movimientos
+// La UI pide solo 100 movimientos; nosotros capturamos la request (headers
+// de auth + body) y la re-ejecutamos con un rango amplio para traer todo el
+// historial disponible.
+
+const LOGIN_URL = "https://www.bci.cl/corporativo/banco-en-linea/pyme";
+const CUENTAS_PREFIX = "https://oss.bci.cl/ms-oss-cuentas/v2/cuentas";
+const MOVIMIENTOS_RE = /oss\.bci\.cl\/bff-oss-resumen-cta\/v[\d.]+\/cuentas\/movimientos/;
+
+// Cuántos años de historial pedir y tope de registros por cuenta.
+const HISTORY_YEARS = 6;
+const MAX_RECORDS = 5000;
+
+const TWO_FACTOR_CONFIG = {
+  keywords: ["bci pass", "segundo factor", "aprobación en tu app", "autorizar en tu app", "confirmar en tu app"],
+  timeoutEnvVar: "BCIPYME_2FA_TIMEOUT_SEC",
+};
+
+// ─── Tipos de la API OSS ─────────────────────────────────────────
+
+interface OssCuenta {
+  tipoCuenta: string;
+  numeroCuenta: string;
+  moneda: string;
+  saldoContable?: number;
+  saldoDisponible?: number;
+  saldoDisponibleTotal?: number;
+  rutEmpresa?: string;
+}
+
+interface OssCuentasResponse {
+  numeroCuentas?: number;
+  detalleCuentas?: OssCuenta[];
+}
+
+interface OssMovimiento {
+  fechaMovimiento?: string; // MM/DD/YYYY
+  fechaContable?: string;   // YYYY-MM-DD
+  descripcion?: string;
+  monto?: string;           // "36850.0000"
+  saldoContable?: number;
+  tipo?: string;            // 'C' = cargo, 'A' = abono
+}
+
+interface OssMovimientosResponse {
+  movimientos?: OssMovimiento[];
+}
+
+interface MovRequestTemplate {
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+/** "2026-06-19" → "19-06-2026" */
+export function isoToDate(iso: string): string {
+  const m = iso.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  return m ? `${m[3]}-${m[2]}-${m[1]}` : iso;
+}
+
+function isoNYearsAgo(years: number): string {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - years);
+  return d.toISOString().slice(0, 10);
+}
+
+function isoToday(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function normalizeMovements(resp: OssMovimientosResponse): BankMovement[] {
+  const out: BankMovement[] = [];
+  for (const m of resp.movimientos ?? []) {
+    const raw = Math.round(parseFloat(m.monto ?? "0"));
+    if (!raw || isNaN(raw)) continue;
+    const amount = m.tipo === "C" ? -raw : raw;
+    const dateSrc = m.fechaContable ?? "";
+    out.push({
+      date: isoToDate(dateSrc),
+      description: (m.descripcion ?? "").trim(),
+      amount,
+      balance: typeof m.saldoContable === "number" ? m.saldoContable : 0,
+      source: MOVEMENT_SOURCE.account,
+    });
+  }
+  return out;
+}
+
+async function bciPymeLogin(
+  page: Page, rut: string, password: string, debugLog: string[],
+  doSave: (page: Page, name: string) => Promise<void>,
+): Promise<{ success: boolean; error?: string; screenshot?: string }> {
+  debugLog.push("1. Navigating to BCI Pyme login...");
+  await page.goto(LOGIN_URL, { waitUntil: "domcontentloaded", timeout: 30000 });
+  await delay(3000);
+  await doSave(page, "01-login-form");
+
+  debugLog.push("2. Filling RUT...");
+  const cleanRut = rut.replace(/[.\-\s]/g, "");
+  const rutBody = cleanRut.slice(0, -1);
+  const rutDv = cleanRut.slice(-1);
+  const filled = await page.evaluate((formatted: string, body: string, dv: string) => {
+    const rutAux = document.getElementById("rut_aux") as HTMLInputElement | null;
+    const rutHidden = document.getElementById("rut") as HTMLInputElement | null;
+    const digHidden = document.getElementById("dig") as HTMLInputElement | null;
+    if (!rutAux) return false;
+    rutAux.value = formatted;
+    rutAux.dispatchEvent(new Event("input", { bubbles: true }));
+    rutAux.dispatchEvent(new Event("change", { bubbles: true }));
+    rutAux.dispatchEvent(new Event("blur", { bubbles: true }));
+    if (rutHidden) rutHidden.value = body;
+    if (digHidden) digHidden.value = dv;
+    return true;
+  }, formatRut(rut), rutBody, rutDv);
+  if (!filled) {
+    const ss = await page.screenshot({ encoding: "base64" });
+    return { success: false, error: "Campo de RUT no encontrado.", screenshot: ss as string };
+  }
+
+  debugLog.push("  Filling password...");
+  const passFilled = await page.evaluate((pass: string) => {
+    const clave = document.getElementById("clave") as HTMLInputElement | null;
+    if (!clave) return false;
+    clave.value = pass;
+    clave.dispatchEvent(new Event("input", { bubbles: true }));
+    clave.dispatchEvent(new Event("change", { bubbles: true }));
+    return true;
+  }, password);
+  if (!passFilled) {
+    const ss = await page.screenshot({ encoding: "base64" });
+    return { success: false, error: "Campo de clave no encontrado.", screenshot: ss as string };
+  }
+
+  await delay(500);
+  debugLog.push("3. Submitting login...");
+  await page.evaluate(() => {
+    const btn = document.querySelector('button[type="submit"]') as HTMLButtonElement | null;
+    if (btn) btn.disabled = false;
+    const form = document.getElementById("frm") as HTMLFormElement | null;
+    if (form) form.submit();
+    else if (btn) btn.click();
+  });
+  try { await page.waitForNavigation({ waitUntil: "networkidle2", timeout: 30000 }); } catch { /* SPA */ }
+  await delay(3000);
+  await doSave(page, "03-post-login");
+
+  if (await detect2FA(page, TWO_FACTOR_CONFIG)) {
+    await doSave(page, "03b-2fa-challenge");
+    const approved = await waitFor2FA(page, debugLog, TWO_FACTOR_CONFIG);
+    if (!approved) {
+      const ss = await page.screenshot({ encoding: "base64" });
+      return { success: false, error: "Timeout esperando segundo factor.", screenshot: ss as string };
+    }
+    await delay(3000);
+  }
+
+  const loginError = await detectLoginError(page);
+  if (loginError) {
+    const ss = await page.screenshot({ encoding: "base64" });
+    return { success: false, error: `Error del banco: ${loginError}`, screenshot: ss as string };
+  }
+
+  // El login exitoso redirige al layout OSS en bel.bci.cl. Si seguimos en la
+  // página de login (banco-en-linea/pyme), las credenciales fueron rechazadas.
+  if (page.url().includes("banco-en-linea/pyme")) {
+    const ss = await page.screenshot({ encoding: "base64" });
+    return { success: false, error: "Login no navegó fuera de la página (RUT/clave incorrectos?).", screenshot: ss as string };
+  }
+
+  debugLog.push("4. Login OK!");
+  return { success: true };
+}
+
+/**
+ * Navega la SPA para gatillar una llamada a la API de movimientos. Solo nos
+ * interesa capturar la request (headers de auth + body con idGrupoEmpresa);
+ * luego la re-ejecutamos con un rango más amplio.
+ */
+async function triggerMovimientos(page: Page, debugLog: string[]): Promise<void> {
+  for (const f of page.frames()) {
+    if (!/oss\.bci\.cl/.test(f.url())) continue;
+    try {
+      const clicked = await f.evaluate(() => {
+        for (const el of document.querySelectorAll("a,button,[role=button],div,span,li,tr")) {
+          const t = (el as HTMLElement).innerText?.trim() ?? "";
+          if (/ver movimientos|mis movimientos|movimientos|cartola/i.test(t) && t.length < 60) {
+            (el as HTMLElement).click();
+            return t.slice(0, 50);
+          }
+        }
+        return null;
+      });
+      if (clicked) {
+        debugLog.push(`  Triggered movimientos via: "${clicked}"`);
+        return;
+      }
+    } catch { /* cross-origin frame not ready */ }
+  }
+  debugLog.push("  WARN: no movimientos menu entry found to click");
+}
+
+/** Re-ejecuta la API de movimientos para una cuenta con rango amplio. */
+async function fetchAccountMovements(
+  page: Page, template: MovRequestTemplate, account: OssCuenta, debugLog: string[],
+): Promise<BankMovement[]> {
+  const ossFrame = page.frames().find((f) => /oss\.bci\.cl/.test(f.url()));
+  if (!ossFrame) {
+    debugLog.push("  WARN: no oss.bci.cl frame for replay");
+    return [];
+  }
+
+  let baseBody: Record<string, unknown>;
+  try { baseBody = JSON.parse(template.body) as Record<string, unknown>; }
+  catch { baseBody = {}; }
+
+  const body = {
+    ...baseBody,
+    numeroDeCuenta: account.numeroCuenta,
+    ...(account.rutEmpresa ? { rutEmpresa: account.rutEmpresa.replace(/\./g, "") } : {}),
+    fechaTransaccionDesde: isoNYearsAgo(HISTORY_YEARS),
+    fechaTransaccionHasta: isoToday(),
+    cantidadDeRegistros: MAX_RECORDS,
+    numeroDeRegistros: MAX_RECORDS,
+  };
+
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  for (const k of ["authorization", "ocp-apim-subscription-key"]) {
+    if (template.headers[k]) headers[k] = template.headers[k];
+  }
+
+  const result = await ossFrame.evaluate(
+    async (url: string, hdrs: Record<string, string>, payload: unknown) => {
+      try {
+        const res = await fetch(url, {
+          method: "POST", headers: hdrs, body: JSON.stringify(payload), credentials: "include",
+        });
+        if (!res.ok) return { error: `HTTP ${res.status}` };
+        return { data: await res.json() };
+      } catch (e) {
+        return { error: e instanceof Error ? e.message : String(e) };
+      }
+    },
+    template.url, headers, body,
+  ) as { data?: OssMovimientosResponse; error?: string };
+
+  if (result.error || !result.data) {
+    debugLog.push(`  Movimientos replay failed for ${account.numeroCuenta}: ${result.error ?? "no data"}`);
+    return [];
+  }
+
+  const movements = normalizeMovements(result.data);
+  if ((result.data.movimientos?.length ?? 0) >= MAX_RECORDS) {
+    debugLog.push(`  WARN: cuenta ${account.numeroCuenta} alcanzó el tope de ${MAX_RECORDS} registros; podría haber más historial.`);
+  }
+  debugLog.push(`  Cuenta ${account.numeroCuenta}: ${movements.length} movimientos`);
+  return movements;
+}
+
+// ─── Main scrape ─────────────────────────────────────────────────
+
+async function scrapeBciPyme(session: BrowserSession, options: ScraperOptions): Promise<ScrapeResult> {
+  const { rut, password, saveScreenshots: doScreenshots } = options;
+  const { page, debugLog, screenshot: doSave } = session;
+  const progress = options.onProgress || (() => {});
+  const bank = "bcipyme";
+
+  // Capturamos la respuesta de cuentas y la request de movimientos vía CDP.
+  let cuentas: OssCuentasResponse | undefined;
+  let movTemplate: MovRequestTemplate | undefined;
+  const onResponse = async (resp: HTTPResponse) => {
+    const url = resp.url();
+    try {
+      if (url.startsWith(CUENTAS_PREFIX) && resp.request().method() === "POST") {
+        cuentas = (await resp.json()) as OssCuentasResponse;
+      } else if (MOVIMIENTOS_RE.test(url) && !movTemplate) {
+        const req = resp.request();
+        const body = req.postData();
+        if (body) movTemplate = { url, headers: req.headers(), body };
+      }
+    } catch { /* body not JSON / already consumed */ }
+  };
+  page.on("response", onResponse);
+
+  try {
+    progress("Abriendo sitio del banco...");
+    const loginResult = await bciPymeLogin(page, rut, password, debugLog, doSave);
+    if (!loginResult.success) {
+      return { success: false, bank, accounts: [], error: loginResult.error, screenshot: loginResult.screenshot, debug: debugLog.join("\n") };
+    }
+
+    progress("Sesión iniciada correctamente");
+    await closePopups(page);
+    await delay(3000); // deja cargar el dashboard (gatilla ms-oss-cuentas)
+
+    // Espera a que el dashboard cargue las cuentas.
+    for (let i = 0; i < 20 && !cuentas; i++) await delay(500);
+    const accountList = cuentas?.detalleCuentas ?? [];
+    debugLog.push(`5. Cuentas detectadas: ${accountList.length}`);
+
+    // Gatilla la API de movimientos para capturar la plantilla de request.
+    progress("Extrayendo movimientos...");
+    await triggerMovimientos(page, debugLog);
+    for (let i = 0; i < 30 && !movTemplate; i++) await delay(500);
+
+    const accounts: AccountBalance[] = [];
+    if (movTemplate && accountList.length > 0) {
+      const multi = accountList.length > 1;
+      for (const acc of accountList) {
+        const movements = await fetchAccountMovements(page, movTemplate, acc, debugLog);
+        const label = `Cuenta ${acc.tipoCuenta} ${acc.numeroCuenta}`;
+        const prefixed = multi
+          ? movements.map((m) => ({ ...m, description: `[${label}] ${m.description}`.trim() }))
+          : movements;
+        accounts.push({
+          label,
+          balance: acc.saldoDisponible ?? acc.saldoDisponibleTotal ?? acc.saldoContable,
+          movements: deduplicateMovements(prefixed),
+        });
+      }
+    } else {
+      // No pudimos capturar la plantilla de movimientos: al menos devolvemos saldos.
+      debugLog.push("  WARN: no se capturó la request de movimientos; devolviendo solo saldos.");
+      for (const acc of accountList) {
+        accounts.push({
+          label: `Cuenta ${acc.tipoCuenta} ${acc.numeroCuenta}`,
+          balance: acc.saldoDisponible ?? acc.saldoDisponibleTotal ?? acc.saldoContable,
+          movements: [],
+        });
+      }
+    }
+
+    const total = accounts.reduce((s, a) => s + a.movements.length, 0);
+    progress(`Listo — ${total} movimientos totales`);
+    await doSave(page, "06-final");
+    const ss = doScreenshots ? ((await page.screenshot({ encoding: "base64" })) as string) : undefined;
+
+    return { success: true, bank, accounts, screenshot: ss, debug: debugLog.join("\n") };
+  } finally {
+    page.off("response", onResponse);
+  }
+}
+
+// ─── Export ──────────────────────────────────────────────────────
+
+const bciPyme: BankScraper = {
+  id: "bcipyme",
+  name: "BCI Pyme",
+  url: "https://www.bci.cl/corporativo/banco-en-linea/pyme",
+  scrape: (options) => runScraper("bcipyme", options, {}, scrapeBciPyme),
+};
+
+export default bciPyme;

--- a/src/banks/bci-pyme.ts
+++ b/src/banks/bci-pyme.ts
@@ -56,6 +56,9 @@ interface OssMovimiento {
   monto?: string;           // "36850.0000"
   saldoContable?: number;
   tipo?: string;            // 'C' = cargo, 'A' = abono
+  // Detalle del "+" en la UI: pares etiqueta/valor (RUT/cuenta/banco destino,
+  // comentario, código de transacción, etc.). Ya viene en esta misma respuesta.
+  detalleMovimiento?: Array<{ label?: string; value?: string }>;
 }
 
 interface OssMovimientosResponse {
@@ -86,20 +89,30 @@ function isoToday(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-export function normalizeMovements(resp: OssMovimientosResponse): BankMovement[] {
+export function normalizeMovements(
+  resp: OssMovimientosResponse,
+  includeDetails = false,
+): BankMovement[] {
   const out: BankMovement[] = [];
   for (const m of resp.movimientos ?? []) {
     const raw = Math.round(parseFloat(m.monto ?? "0"));
     if (!raw || isNaN(raw)) continue;
     const amount = m.tipo === "C" ? -raw : raw;
     const dateSrc = m.fechaContable ?? "";
-    out.push({
+    const mov: BankMovement = {
       date: isoToDate(dateSrc),
       description: (m.descripcion ?? "").trim(),
       amount,
       balance: typeof m.saldoContable === "number" ? m.saldoContable : 0,
       source: MOVEMENT_SOURCE.account,
-    });
+    };
+    if (includeDetails && Array.isArray(m.detalleMovimiento)) {
+      mov.details = m.detalleMovimiento.map((d) => ({
+        label: (d.label ?? "").replace(/:\s*$/, "").trim(),
+        value: (d.value ?? "").trim(),
+      }));
+    }
+    out.push(mov);
   }
   return out;
 }
@@ -220,6 +233,7 @@ async function triggerMovimientos(page: Page, debugLog: string[]): Promise<void>
 /** Re-ejecuta la API de movimientos para una cuenta con rango amplio. */
 async function fetchAccountMovements(
   page: Page, template: MovRequestTemplate, account: OssCuenta, debugLog: string[],
+  includeDetails = false,
 ): Promise<BankMovement[]> {
   const ossFrame = page.frames().find((f) => /oss\.bci\.cl/.test(f.url()));
   if (!ossFrame) {
@@ -266,7 +280,7 @@ async function fetchAccountMovements(
     return [];
   }
 
-  const movements = normalizeMovements(result.data);
+  const movements = normalizeMovements(result.data, includeDetails);
   if ((result.data.movimientos?.length ?? 0) >= MAX_RECORDS) {
     debugLog.push(`  WARN: cuenta ${account.numeroCuenta} alcanzó el tope de ${MAX_RECORDS} registros; podría haber más historial.`);
   }
@@ -277,7 +291,7 @@ async function fetchAccountMovements(
 // ─── Main scrape ─────────────────────────────────────────────────
 
 async function scrapeBciPyme(session: BrowserSession, options: ScraperOptions): Promise<ScrapeResult> {
-  const { rut, password, saveScreenshots: doScreenshots } = options;
+  const { rut, password, saveScreenshots: doScreenshots, details: includeDetails = false } = options;
   const { page, debugLog, screenshot: doSave } = session;
   const progress = options.onProgress || (() => {});
   const bank = "bcipyme";
@@ -324,7 +338,7 @@ async function scrapeBciPyme(session: BrowserSession, options: ScraperOptions): 
     if (movTemplate && accountList.length > 0) {
       const multi = accountList.length > 1;
       for (const acc of accountList) {
-        const movements = await fetchAccountMovements(page, movTemplate, acc, debugLog);
+        const movements = await fetchAccountMovements(page, movTemplate, acc, debugLog, includeDetails);
         const label = `Cuenta ${acc.tipoCuenta} ${acc.numeroCuenta}`;
         const prefixed = multi
           ? movements.map((m) => ({ ...m, description: `[${label}] ${m.description}`.trim() }))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ Opciones:
   --headful        Abrir Chrome visible (para debugging)
   --pretty         Formatear JSON con indentación
   --movements      Solo imprimir movimientos (sin metadata)
+  --details        Incluir el detalle ampliado de cada movimiento (BCI Pyme)
   --owner <T|A|B>  Filtro Titular/Adicional para TC (default: B = todos)
   --help, -h       Mostrar esta ayuda
 
@@ -128,6 +129,7 @@ Ejemplos:
     chromePath: process.env.CHROME_PATH,
     saveScreenshots: flags.has("--screenshots"),
     headful: flags.has("--headful"),
+    details: flags.has("--details"),
     ...(owner && { owner }),
     onProgress: isTTY ? (step) => spinner.update(step) : undefined,
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,9 @@
 import { config } from 'dotenv';
 import { banks, listBanks, getBank } from "./index.js";
 import { Spinner } from "./utils.js";
-config();
+// quiet: true evita que dotenv imprima su banner en stdout, que corrompía
+// la salida JSON (ej: `--bank x --pretty | jq`).
+config({ quiet: true });
 
 async function main() {
   const args = process.argv.slice(2);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import bancosecurity from "./banks/bancosecurity.js";
 import bchile from "./banks/bchile.js";
 import bci from "./banks/bci.js";
+import bciPyme from "./banks/bci-pyme.js";
 import bestado from "./banks/bestado.js";
 import bice from "./banks/bice.js";
 import edwards from "./banks/edwards.js";
@@ -16,6 +17,7 @@ export const banks: Record<string, BankScraper> = {
   bancosecurity,
   bchile,
   bci,
+  bcipyme: bciPyme,
   bestado,
   bice,
   edwards,
@@ -57,6 +59,7 @@ export { MOVEMENT_SOURCE, CARD_OWNER } from "./types.js";
 // Re-export individual banks for direct import
 export { default as bchile } from "./banks/bchile.js";
 export { default as bci } from "./banks/bci.js";
+export { default as bciPyme } from "./banks/bci-pyme.js";
 export { default as bestado } from "./banks/bestado.js";
 export { default as bice } from "./banks/bice.js";
 export { default as edwards } from "./banks/edwards.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,13 @@ export interface BankMovement {
   installments?: string;
   /** Monto total de la compra (distinto de amount cuando es en cuotas) */
   totalAmount?: number;
+  /**
+   * Detalle ampliado del movimiento (el contenido del "+" en la UI del banco):
+   * pares etiqueta/valor tal cual los entrega el portal (ej: RUT destinatario,
+   * cuenta de destino, banco, comentario, código de transacción). Solo se
+   * llena cuando el scraper se ejecuta con la opción `details`.
+   */
+  details?: Array<{ label: string; value: string }>;
 }
 
 /** Saldo y movimientos de una cuenta bancaria */
@@ -125,6 +132,11 @@ export interface ScraperOptions extends BankCredentials {
   saveScreenshots?: boolean;
   /** Si es true, usa headless: false (para debugging visual) */
   headful?: boolean;
+  /**
+   * Si es true, incluye el detalle ampliado de cada movimiento en
+   * `BankMovement.details` (cuando el banco lo soporta). Default: false.
+   */
+  details?: boolean;
   /** Filtro Titular/Adicional para TC (ej: "T" = titular, "A" = adicional, "B" = todos). Default: "B" */
   owner?: "T" | "A" | "B";
   /** Callback de progreso para mostrar estado al usuario */


### PR DESCRIPTION
## Qué agrega

Un nuevo banco `bcipyme` para el portal **BCI Pyme / Banca Empresas** (`banco-en-linea/pyme`), que no es accesible desde el portal de personas.

A diferencia de `bci` (personas, iframes + BCI Pass), el portal Pyme redirige tras el login al portal **OSS** (`oss.bci.cl`), una SPA alimentada por una API REST JSON. Por eso el scraper **intercepta la API** en lugar de raspar tablas HTML:

- Login con RUT + clave (mismo formulario que personas, distinto canal).
- Cuentas y saldos desde `ms-oss-cuentas/v2/cuentas`.
- Movimientos desde `bff-oss-resumen-cta/.../cuentas/movimientos`. La UI solo solicita los últimos **100** registros; el scraper captura esa request (headers de auth + body) y la **re-ejecuta con un rango amplio** para traer todo el historial disponible.
- Movimientos normalizados a `dd-mm-yyyy`, montos con signo (C=cargo, A=abono) y saldo corrido desde `saldoContable`.
- Soporte multi-cuenta: prefija la descripción con la cuenta de origen.

## Extra

Silencia el banner de `dotenv` en `cli.ts` (`config({ quiet: true })`), que se imprimía en stdout y corrompía la salida JSON al usar, por ejemplo, `--bank x --pretty | jq`. Afecta a todos los bancos.

## Pruebas

- `npm run build` y `npm test` pasan (incluye tests unitarios nuevos del normalizador).
- Probado end-to-end contra una cuenta real (vía CLI y `npx`): retorna el historial completo de la cuenta corriente con saldos correctos (el saldo declarado coincide con el saldo corrido del último movimiento).

## Notas / limitaciones

- Probado con un perfil de **una sola cuenta corriente** (sin tarjetas de crédito). El soporte multi-cuenta está implementado pero aún no validado contra un login Pyme con varias cuentas.
- No se incluyen credenciales ni datos bancarios reales (fixtures de test son sintéticos).