### PR TITLE
fix(falabella): robust 'Mi cuenta' login button click

### DIFF
--- a/src/banks/falabella.ts
+++ b/src/banks/falabella.ts
@@ -78,12 +78,37 @@ async function login(page: Page, rut: string, password: string, debugLog: string
   } catch { /* no banner */ }
   await screenshotIfEnabled(page, "01-homepage", doScreenshots, debugLog);
 
-  // Click "Mi cuenta" (triggers navigation)
+  // Click "Mi cuenta" (opens login form).
+  // The header button uses aria-label="Button", so getByRole(name="Mi cuenta")
+  // fails. Prefer #btn-auth-normal, then visible text matches (skip hidden twins).
   debugLog.push("2. Clicking 'Mi cuenta'...");
   progress("Ingresando a Mi cuenta...");
-  try {
-    await page.locator('a, button').filter({ hasText: "Mi cuenta" }).first().click({ timeout: 5000 });
-  } catch { /* may cause navigation context change */ }
+  await page.waitForSelector("#main-header__sub-content, #btn-auth-normal", { timeout: 20000 }).catch(() => {});
+  const miCuentaSelectors = [
+    "#btn-auth-normal",
+    '#main-header__sub-content button:has-text("Mi cuenta")',
+    'button:has-text("Mi cuenta")',
+  ];
+  let miCuentaClicked = false;
+  for (const selector of miCuentaSelectors) {
+    const loc = page.locator(selector);
+    const count = await loc.count();
+    for (let i = 0; i < count; i++) {
+      const candidate = loc.nth(i);
+      if (!(await candidate.isVisible({ timeout: 1500 }).catch(() => false))) continue;
+      try {
+        await candidate.click({ timeout: 5000, force: true });
+        debugLog.push(`  Clicked 'Mi cuenta' via ${selector}[${i}]`);
+        miCuentaClicked = true;
+        break;
+      } catch { /* try next */ }
+    }
+    if (miCuentaClicked) break;
+  }
+  if (!miCuentaClicked) {
+    const ss = (await page.screenshot()).toString("base64");
+    return { success: false, error: "No se encontró el botón 'Mi cuenta'", screenshot: ss };
+  }
   await page.waitForLoadState("networkidle").catch(() => {});
   await delay(3000);
   await screenshotIfEnabled(page, "02-login-form", doScreenshots, debugLog);


### PR DESCRIPTION
## Summary
- Fixes Falabella homepage login entry when the «Mi cuenta» header button is present but not matched reliably.
- The button uses `aria-label="Button"` (accessible name ≠ «Mi cuenta»), and a broad `a, button` `.first()` can hit a hidden twin.
- Prefer `#btn-auth-normal`, then visible `#main-header__sub-content button:has-text("Mi cuenta")`, then other visible text matches; fail clearly if none work.

Found while porting this flow into [fintself](https://github.com/jorgeortizfuentes/fintself/pull/30).

## Test plan
- [ ] `npx open-banking-chile --bank falabella --headful --screenshots` (or local equivalent)
- [ ] Confirm debug log shows `Clicked 'Mi cuenta' via #btn-auth-normal[...]` (or header fallback)
- [ ] Login form (RUT) appears after the click