### PR TITLE
fix(santander): track account currency and stop losing non-primary ac…

### DIFF
--- a/src/banks/santander.ts
+++ b/src/banks/santander.ts
@@ -174,7 +174,7 @@ const TWO_FACTOR_CONFIG = {
 
 // ─── Santander-specific helpers ──────────────────────────────────────
 
-type MovementAccount = { index: number; label: string };
+type MovementAccount = { index: number; label: string; currency: "CLP" | "USD" };
 
 async function getLoginFrame(page: Page): Promise<Frame | null> {
   const handle = await page.$("iframe#login-frame");
@@ -184,7 +184,7 @@ async function getLoginFrame(page: Page): Promise<Frame | null> {
 async function listMovementAccounts(page: Page): Promise<MovementAccount[]> {
   return await page.evaluate(() => {
     const slides = Array.from(document.querySelectorAll("#tabs-carousel-movs .swiper-slide"));
-    const out: Array<{ index: number; label: string }> = [];
+    const out: Array<{ index: number; label: string; currency: "CLP" | "USD" }> = [];
     for (let i = 0; i < slides.length; i++) {
       const slide = slides[i] as HTMLElement;
       const text = slide.innerText?.replace(/\s+/g, " ").trim() || "";
@@ -193,7 +193,10 @@ async function listMovementAccounts(page: Page): Promise<MovementAccount[]> {
       const numberMatch = text.match(/\d(?:[\s.]\d+){3,}/);
       const type = typeMatch ? `Cuenta ${typeMatch[1]}` : "Cuenta";
       const number = numberMatch ? numberMatch[0].replace(/\s+/g, " ").trim() : `#${i + 1}`;
-      out.push({ index: i, label: `${type} ${number}`.trim() });
+      // Santander muestra "Cuenta Corriente Dólar" para la cuenta en USD — no hay otro
+      // indicador estructurado (la API de movimientos tampoco trae moneda ni cuenta).
+      const currency: "CLP" | "USD" = /US\$|USD|d[oó]lar/i.test(text) ? "USD" : "CLP";
+      out.push({ index: i, label: `${type} ${number}`.trim(), currency });
     }
     return out;
   });
@@ -430,36 +433,71 @@ async function scrapeSantander(
   // Multi-account handling
   const accounts = await listMovementAccounts(page);
   if (accounts.length > 0) {
-    debugLog.push(`  Accounts: ${accounts.map((a) => a.label).join(" | ")}`);
+    debugLog.push(`  Accounts: ${accounts.map((a) => `${a.label} [${a.currency}]`).join(" | ")}`);
   }
 
   let movements: BankMovement[] = [];
 
-  // Try API interception for checking account
-  const checkingCaptures = await interceptor.waitFor("santander-checking", 10_000);
-  if (checkingCaptures.length > 0) {
-    debugLog.push(`  Checking API: ${checkingCaptures.length} response(s) captured`);
-    const apiMovements = normalizeSantanderCheckingApiMovements(checkingCaptures);
-    debugLog.push(`  Checking API movements: ${apiMovements.length}`);
-    if (apiMovements.length > 0) {
+  // La API de cuentas se consulta al cargar la página, para la cuenta que esté activa en el
+  // carrusel — la reutilizamos para esa cuenta en vez de perderla al hacer `clear()` más abajo.
+  const initialCaptures = await interceptor.waitFor("santander-checking", 10_000);
+  const initialActiveIndex = await page.evaluate(() => {
+    const slides = Array.from(document.querySelectorAll("#tabs-carousel-movs .swiper-slide"));
+    return slides.findIndex((s) => (s as HTMLElement).className.includes("swiper-slide-active"));
+  });
+
+  if (accounts.length <= 1) {
+    const currency = accounts[0]?.currency ?? "CLP";
+    if (initialCaptures.length > 0) {
+      debugLog.push(`  Checking API: ${initialCaptures.length} response(s) captured`);
+      const apiMovements = normalizeSantanderCheckingApiMovements(initialCaptures);
+      debugLog.push(`  Checking API movements: ${apiMovements.length}`);
+      for (const m of apiMovements) m.currency = currency;
       movements.push(...apiMovements);
     }
-  }
+    if (movements.length === 0) {
+      debugLog.push("  Checking API: no data, falling back to HTML extraction");
+      const domMovements = await paginateAndExtract(page, extractAccountMovements, debugLog);
+      for (const m of domMovements) m.currency = currency;
+      movements.push(...domMovements);
+    }
+  } else {
+    // Con varias cuentas, la API se dispara una vez por cuenta activa: hay que cambiar de
+    // cuenta en el carrusel y esperar una captura nueva por cada una — si no, la
+    // intercepción solo ve la que estaba activa al cargar y las demás se pierden en
+    // silencio (nunca se scrapean, ni siquiera mezcladas con las otras).
+    for (const account of accounts) {
+      let acctCaptures: unknown[];
+      let onAccountPage: boolean;
 
-  if (movements.length === 0) {
-    debugLog.push("  Checking API: no data, falling back to HTML extraction");
-    if (accounts.length <= 1) {
-      movements = await paginateAndExtract(page, extractAccountMovements, debugLog);
-    } else {
-      for (const account of accounts) {
-        const switched = await selectMovementAccount(page, account.index);
-        if (!switched) {
+      if (account.index === initialActiveIndex && initialCaptures.length > 0) {
+        acctCaptures = initialCaptures;
+        onAccountPage = true;
+      } else {
+        interceptor.clear("santander-checking");
+        onAccountPage = await selectMovementAccount(page, account.index);
+        if (!onAccountPage) {
           debugLog.push(`  Could not switch to ${account.label}`);
           continue;
         }
+        acctCaptures = await interceptor.waitFor("santander-checking", 8_000);
+      }
+
+      const apiMovements = acctCaptures.length > 0 ? normalizeSantanderCheckingApiMovements(acctCaptures) : [];
+
+      if (apiMovements.length > 0) {
+        for (const m of apiMovements) m.currency = account.currency;
+        movements.push(...apiMovements);
+        debugLog.push(`  ${account.label} [${account.currency}] (API): ${apiMovements.length} movement(s)`);
+      } else if (onAccountPage) {
+        // Si esta cuenta no expone movimientos por esta API (ej. Línea de Crédito, que no
+        // siempre es un producto "current-account" — o devuelve una respuesta con 0
+        // movimientos en un formato distinto), volvemos al scraping de la tabla HTML. Ya
+        // estamos en la página de esta cuenta, no hace falta volver a cambiar.
         const acctMovements = await paginateAndExtract(page, extractAccountMovements, debugLog);
+        for (const m of acctMovements) m.currency = account.currency;
         movements.push(...acctMovements);
-        debugLog.push(`  ${account.label}: ${acctMovements.length} movement(s)`);
+        debugLog.push(`  ${account.label} [${account.currency}] (HTML): ${acctMovements.length} movement(s)`);
       }
     }
   }

--- a/src/intercept.test.ts
+++ b/src/intercept.test.ts
@@ -100,6 +100,47 @@ describe("createInterceptor", () => {
     expect(result).toEqual([]);
   });
 
+  it("clear discards previously captured data for the given endpoint id", async () => {
+    const { page, simulateCapture } = mockPage();
+    const interceptor = await createInterceptor(page, [{ id: "acct", urlPrefix: "https://bank.cl/api" }]);
+
+    simulateCapture("acct", { page: 1 });
+    expect(interceptor.getAll("acct")).toHaveLength(1);
+
+    interceptor.clear("acct");
+    expect(interceptor.getAll("acct")).toEqual([]);
+  });
+
+  it("clear only affects the given endpoint id", async () => {
+    const { page, simulateCapture } = mockPage();
+    const interceptor = await createInterceptor(page, [
+      { id: "checking", urlPrefix: "https://bank.cl/checking" },
+      { id: "cc", urlPrefix: "https://bank.cl/cards" },
+    ]);
+
+    simulateCapture("checking", { movements: [] });
+    simulateCapture("cc", { movements: [] });
+
+    interceptor.clear("checking");
+
+    expect(interceptor.getAll("checking")).toEqual([]);
+    expect(interceptor.getAll("cc")).toHaveLength(1);
+  });
+
+  it("waitFor captures a fresh response after clear (per-account re-fetch pattern)", async () => {
+    const { page, simulateCapture } = mockPage();
+    const interceptor = await createInterceptor(page, [{ id: "checking", urlPrefix: "https://bank.cl" }]);
+
+    simulateCapture("checking", { account: "A" });
+    expect(await interceptor.waitFor("checking")).toEqual([{ account: "A" }]);
+
+    interceptor.clear("checking");
+    setTimeout(() => simulateCapture("checking", { account: "B" }), 20);
+
+    const result = await interceptor.waitFor("checking", 500);
+    expect(result).toEqual([{ account: "B" }]);
+  });
+
   it("ignores malformed JSON from the browser bridge", async () => {
     const { page } = mockPage();
     let captureCallback: ((id: string, dataJson: string) => void) | undefined;

--- a/src/intercept.ts
+++ b/src/intercept.ts
@@ -15,6 +15,12 @@ export interface Interceptor {
    * Returns the captured responses, or an empty array if the timeout is reached.
    */
   waitFor(id: string, timeoutMs?: number): Promise<unknown[]>;
+  /**
+   * Discards previously captured responses for the given endpoint id. Useful when the same
+   * endpoint is called once per account (e.g. after switching accounts in a carousel) and
+   * captures need to be attributed to the account that was active when they arrived.
+   */
+  clear(id: string): void;
 }
 
 /**
@@ -145,6 +151,10 @@ export async function createInterceptor(
         await sleep(200);
       }
       return captures.get(id) ?? [];
+    },
+
+    clear(id: string): void {
+      captures.delete(id);
     },
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,8 @@ export interface BankMovement {
   balance: number;
   /** Origen: cuenta corriente, TC no facturada, TC facturada */
   source: MovementSource;
+  /** Moneda de la cuenta de origen (hoy solo lo distingue Santander, para bancos que tienen cuentas CLP y USD) */
+  currency?: "CLP" | "USD";
   /** Titular o adicional de la tarjeta */
   owner?: CardOwner;
   /** Identificador de la tarjeta (ej: "****8335") — útil cuando hay múltiples tarjetas */


### PR DESCRIPTION
…counts

listMovementAccounts() enumeraba todas las cuentas del carrusel de movimientos (cuenta corriente, línea de crédito, cuenta USD) pero descartaba de cuál venía cada tanda de movimientos, así que los usuarios con más de una cuenta terminaban con movimientos CLP y USD mezclados en una sola lista sin distinción.

Por separado, el camino nuevo de interceptación de API solo espera una única respuesta de "santander-checking" justo al llegar a la página de movimientos — la de la cuenta que esté activa por defecto. Como nunca cambia de cuenta en el carrusel, los movimientos de cualquier otra cuenta se pierden completamente en silencio (no se mezclan, directamente nunca se piden), una regresión respecto al fallback viejo de tabla HTML, que sí recorría todas las cuentas.

Esto agrega:
- BankMovement.currency (opcional, "CLP" | "USD"), asignado por movimiento según el label de cada cuenta en el carrusel (ej. "Cuenta Corriente Dólar").
- Interceptor.clear(id), para poder rearmar el endpoint de cuenta corriente por cada cuenta al cambiar en el carrusel — si no, waitFor() seguía devolviendo la captura vieja de la primera cuenta.
- Un loop por cuenta en scrapeSantander que reutiliza la captura inicial para la cuenta que estaba activa al cargar, y para cada cuenta restante cambia + limpia + vuelve a esperar, cayendo al fallback HTML existente cuando una cuenta no expone datos por esa API (se observó con una cuenta "Línea de Crédito", que no es un producto de cuenta corriente típico).

Validado contra una cuenta real de Santander con 3 productos (cuenta corriente CLP, línea de crédito, cuenta corriente USD): antes solo se extraían los X movimientos de la primera cuenta; ahora vuelven las 3 cuentas (X + Y + Z) con la moneda correcta y sin mezclar entre cuentas.