### PR TITLE
feat(santander): exponer accountingDate como postedDate

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Campos opcionales en `BankMovement`:
 | `owner`        | `"titular"` o `"adicional"` (Falabella CMR)                                 |
 | `card`         | Máscara de la tarjeta, ej: `"****8335"` (BChile, Falabella)                 |
 | `installments` | Cuotas en formato `NN/NN`, ej: `"02/06"` = cuota 2 de 6                     |
+| `postedDate`   | Fecha de acreditación en la cuenta, cuando difiere de la de operación (Santander) |
 | `totalAmount`  | Monto total de la compra cuando es en cuotas (Falabella)                    |
 
 ## Seguridad

--- a/src/banks/santander.test.ts
+++ b/src/banks/santander.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { normalizeDate } from "../utils.js";
 import { MOVEMENT_SOURCE } from "../types.js";
 import {
   isSaldoInicial,
@@ -176,6 +177,47 @@ describe("normalizeSantanderCheckingApiMovements", () => {
 });
 
 // ─── normalizeSantanderUnbilledApiMovements ──────────────────────
+
+describe("normalizeSantanderCheckingApiMovements — postedDate", () => {
+  it("expone accountingDate como postedDate cuando difiere de la fecha de operación", () => {
+    const result = normalizeSantanderCheckingApiMovements([
+      {
+        movements: [
+          {
+            transactionDate: "2026-01-15",
+            accountingDate: "2026-01-17",
+            movementAmount: "00000010000000-",
+            chargePaymentFlag: "D",
+            observation: "COMPRA SUPERMERCADO",
+            expandedCode: "",
+          },
+        ],
+      },
+    ]);
+    // El formato lo define normalizeDate (ver #88); acá probamos el cableado:
+    // que accountingDate llegue a postedDate y que sea una fecha distinta de date.
+    expect(result[0].date).toBe(normalizeDate("2026-01-15"));
+    expect(result[0].postedDate).toBe(normalizeDate("2026-01-17"));
+    expect(result[0].postedDate).not.toBe(result[0].date);
+  });
+
+  it("omite postedDate cuando el banco no entrega accountingDate", () => {
+    const result = normalizeSantanderCheckingApiMovements([
+      {
+        movements: [
+          {
+            transactionDate: "2026-01-15",
+            movementAmount: "00000010000000-",
+            chargePaymentFlag: "D",
+            observation: "COMPRA SUPERMERCADO",
+            expandedCode: "",
+          },
+        ],
+      },
+    ]);
+    expect(result[0].postedDate).toBeUndefined();
+  });
+});
 
 describe("normalizeSantanderUnbilledApiMovements", () => {
   it("returns empty array for empty captures", () => {

--- a/src/banks/santander.ts
+++ b/src/banks/santander.ts
@@ -28,7 +28,8 @@ const SANTANDER_CC_BILLED_API_PREFIX =
 // ─── API response normalizers ────────────────────────────────────
 
 interface SantanderCheckingApiMovement {
-  transactionDate: string; // "2026-03-19"
+  transactionDate: string; // "2026-03-19" — fecha de la operación
+  accountingDate?: string; // "2026-03-21" — fecha de acreditación en la cuenta
   movementAmount: string; // "00000010000000-" (centavos, trailing - = debit)
   chargePaymentFlag: string; // "D" = debit, "H" = haber/credit
   observation: string;
@@ -55,12 +56,16 @@ export function normalizeSantanderCheckingApiMovements(captures: unknown[]): Ban
         const balDigits = m.newBalance.replace(/[^0-9]/g, "");
         balance = Math.round(parseInt(balDigits, 10) / 100);
       }
+      // El endpoint entrega las dos fechas y suelen diferir: accountingDate es cuándo
+      // se acreditó, transactionDate cuándo se hizo la operación.
+      const postedDate = m.accountingDate ? normalizeDate(m.accountingDate) : undefined;
       movements.push({
         date: normalizeDate(m.transactionDate),
         description,
         amount,
         balance,
         source: MOVEMENT_SOURCE.account,
+        ...(postedDate ? { postedDate } : {}),
       });
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,15 @@ export interface BankMovement {
   owner?: CardOwner;
   /** Identificador de la tarjeta (ej: "****8335") — útil cuando hay múltiples tarjetas */
   card?: string;
+  /**
+   * Fecha en que el movimiento se acreditó en la cuenta, cuando el banco la expone
+   * por separado de `date` (formato dd-mm-yyyy).
+   *
+   * `date` es la fecha de la operación (cuándo se hizo); `postedDate` es cuándo entró
+   * a la cuenta. Suelen diferir por días y la distinción importa para separar gasto
+   * devengado de salida de caja. Solo se completa si el banco entrega ambas.
+   */
+  postedDate?: string;
   /** Cuotas (ej: "01/01", "02/06") */
   installments?: string;
   /** Monto total de la compra (distinto de amount cuando es en cuotas) */


### PR DESCRIPTION
## Contexto

El endpoint de cuenta corriente de Santander (`current-accounts/transactions`) devuelve **dos fechas por movimiento** y hoy el scraper descarta una:

| Campo | Significado |
|---|---|
| `transactionDate` | cuándo se hizo la operación — es el que se usa hoy para `date` |
| `accountingDate` | cuándo se acreditó en la cuenta — se descarta |

Verificando contra una cuenta real: **15 de 28 movimientos tienen las dos fechas distintas**. No es un caso de borde.

## Por qué importa

Es la diferencia entre gasto devengado y salida de caja. Una compra hecha el 31 de julio y acreditada el 1 de agosto pertenece a julio o a agosto según qué pregunta se esté respondiendo:

- *"¿en qué gasté este mes?"* → fecha de operación
- *"¿cuánta plata salió de mi cuenta este mes?"* → fecha de acreditación

Con una sola fecha expuesta, el consumer no puede elegir: le toca la que el scraper haya decidido. Y para quien ya tiene datos guardados, cambiar de una a la otra le mueve movimientos de mes.

## Cambios

- `BankMovement.postedDate?: string` — opcional, se puebla **solo** si el banco entrega ambas fechas. Si el campo falta es porque el dato no existe, no porque coincida con `date`: preferí eso a que la ausencia sea ambigua.
- `santander.ts`: `accountingDate` agregado a la interfaz de la API (no estaba declarado) y propagado.
- 2 tests: que el dato se propague y que se omita cuando el banco no lo manda.
- README: campo documentado en la tabla de opcionales.

`npm test` → 65 pasando. `npm run build` OK.

## Notas

**Sobre el formato.** Los tests usan `normalizeDate()` en las aserciones en vez de fijar un string. Ambas fechas de este endpoint vienen en ISO, y hoy `normalizeDate` las deja pasar sin convertir (eso lo trato aparte en #88). Escribiéndolos así, estos tests prueban el cableado y no el formato, y siguen pasando con o sin ese otro PR.

**Sobre el nombre.** Usé `postedDate` por la convención de la industria (*transaction date* vs *posted date*), pero si preferís `accountingDate` —más literal respecto de la API— o `settlementDate`, lo cambio sin problema.

**Sobre otros bancos.** Solo lo poblé en Santander porque es el único donde pude verificar que la API entrega las dos. Si otros bancos exponen algo equivalente, el campo ya queda disponible para completarlo.
